### PR TITLE
Update documentation for Cursor 3: Revise README to reflect compatibi…

### DIFF
--- a/.cursor/rules/agent-teams.mdc
+++ b/.cursor/rules/agent-teams.mdc
@@ -13,11 +13,16 @@ Use this rule when the work is best handled by multiple agents or explicitly sep
 - Give each role a distinct objective, owned surface, and stopping point.
 - Do not create overlapping ownership without a clear reason.
 
+## Multiple concurrent Cursor sessions
+
+Cursor 3 can run **several agent sessions in parallel** (for example from the sidebar). The same rules apply as for parallel roles or subagent branches: use parallel sessions only for **independent** workstreams, keep **non-overlapping ownership** of files and decisions, and **serialize** anything that would race the same artifact. More sessions visible at once does not make conflicting edits safer.
+
 ## Handoff Contract
 
 Every handoff should state:
 
 - current goal
+- **which repo or workspace root** when more than one is in play
 - files, dirs, or questions owned
 - findings or artifacts produced
 - open risks or assumptions

--- a/.cursor/rules/cursor-agent-orchestration.mdc
+++ b/.cursor/rules/cursor-agent-orchestration.mdc
@@ -11,6 +11,19 @@ Use this rule for deep or exhaustive tasks where coordination matters more than 
 
 The main agent should own synthesis. Plans, subagents, and task tracking exist to reduce context load and make large work safer.
 
+## Local and cloud sessions (optional)
+
+Cursor 3 emphasizes moving work between **local** and **cloud** agent sessions. Treat this as workflow guidance, not a requirement:
+
+- Prefer **local** when you need fast edit–run–debug loops, full filesystem access, or machine-specific verification.
+- Consider **cloud** when a task should keep running while you are away, or when you want continuation without tying up the local machine—then **hand back to local** to validate on the real environment when claims are environment-specific.
+
+Handoffs should still use explicit goals, owned paths, and what was verified (see `agent-teams.mdc`).
+
+## Parallel sessions and the sidebar
+
+Cursor 3 can show **many agent sessions** at once (including from other surfaces). That mirrors the idea of concurrent **`Task`** / subagent delegation: only parallelize **independent** slices, merge results in one synthesis step, and avoid two sessions racing the same files. The UI makes parallelism easier; it does not remove the need for clear ownership.
+
 ## When to Plan
 
 Plan when:
@@ -22,17 +35,17 @@ Plan when:
 Do not over-plan one-file fixes or straightforward edits.
 Use the environment's active planning workflow or mode when it exists instead of assuming a specific planning tool name.
 
-## When to Use Subagents
+## When to Use Task (subagents)
 
-Use `Subagent` when:
+In Composer-style Cursor agents the tool is usually **`Task`** (subagent-style delegation; types such as explore, debugger, verifier—see the live schema). Use it when:
 - repo exploration is broad and would pollute main context
 - independent investigations can run in parallel
 - a verifier or debugger pass would help
 - the task has a long-running research branch
 
-Avoid subagent overhead for instant or light work.
+Avoid delegation overhead for instant or light work.
 
-When several independent branches exist, do not launch them serially by habit. Launch them together with separate scopes and merge their results in the main thread.
+When several independent branches exist, do not launch them serially by habit. Launch multiple `Task` calls together with separate scopes and merge their results in the main thread.
 
 ## Delegation Pattern
 
@@ -86,5 +99,7 @@ Do not postpone all checks to the end. Verify per phase:
 - after code changes, run the smallest relevant command
 - after UI changes, use browser checks when needed
 - after a major feature phase, run broader validation
+
+Use the **diff / review surface** in Cursor when it helps you stage, review, and ship; keep claims aligned with the always-on status and verification rule regardless of UI.
 
 Final user-facing completion claims should follow the always-on status and verification rule rather than ad-hoc wording.

--- a/.cursor/rules/cursor-mcp-optimization.mdc
+++ b/.cursor/rules/cursor-mcp-optimization.mdc
@@ -77,6 +77,10 @@ Direct guidance for Cursor's MCP tools. Use the right tool for each job.
 4. Do not infer hidden parameters or old API versions
 ```
 
+## Marketplace plugins
+
+Plugins installed from the [Cursor Marketplace](https://cursor.com/marketplace) extend agents with MCPs, skills, and related capabilities. Treat them like any other MCP surface: **inventory** what the session exposes, **read descriptors/schemas** before first use, then call the smallest valid tool—same as in `tool-discovery.mdc`.
+
 ## Capability Mapping Checklist
 
 Before acting, confirm:

--- a/.cursor/rules/cursor-tools-mastery.mdc
+++ b/.cursor/rules/cursor-tools-mastery.mdc
@@ -7,6 +7,13 @@ alwaysApply: false
 
 Keep durable behavior in the core rule. Use this file for current Cursor tool-selection patterns.
 
+## Cursor 3 workspace
+
+In Cursor 3, agent work is centered in the **Agents** experience. Open it from the command palette: **Agents Window** (for example `Cmd+Shift+P` on macOS, as described in the [Cursor 3 announcement](https://cursor.com/blog/cursor-3)).
+
+- **Multi-workspace / multi-repo:** the UI can surface several workspaces at once. Name the repo or root path when handing off work, opening files, or running commands so edits land in the intended tree.
+- **Integrated browser:** prefer the IDE’s built-in browser for local UI verification when it is exposed in your session; it matches the “snapshot-first” flow in Browser Guidance below.
+
 ## Golden Rule
 
 For significant actions:
@@ -20,29 +27,44 @@ Validate with the lightest useful verification
 
 ## Default Tool Map
 
-- Known file: `ReadFile`
-- File discovery: `Glob`
-- Exact text search: `rg`
-- Conceptual discovery: `SemanticSearch`
-- Surgical edit: `ApplyPatch`
-- File removal: `Delete`
-- Commands, tests, git, installs: `Shell`
-- Web research: `WebSearch`, `WebFetch`
-- Structured questions: `AskQuestion`
-- Task tracking: `TodoWrite`
-- Planning: use the environment's current planning workflow or mode when it exists
-- Isolated investigation: `Subagent`
+**Composer 2 / Cursor agent (typical names in current desktop agents):** the session usually exposes something close to:
+
+| Step | Tool name | Notes |
+|------|-----------|--------|
+| Read a path | `Read` | Prefer over shell `cat`/`sed` |
+| Search by pattern | `Grep` | Ripgrep-backed; use for exact symbols and strings |
+| Search by meaning | `SemanticSearch` | “Where does X happen?” not exact text |
+| List paths | `Glob` | File discovery by pattern |
+| Edit in place | `StrReplace` | Surgical edits; read the file first |
+| Create or replace whole file | `Write` | Use when there is no stable old_string to patch |
+| Remove file | `Delete` | |
+| Terminal | `Shell` | Builds, tests, git, installs |
+| Web | `WebSearch`, `WebFetch` | |
+| Ask user | `AskQuestion` | |
+| Track steps | `TodoWrite` | |
+| Delegate branch work | `Task` | Subagent-style runs (types such as explore, debugger, verifier—see schema) |
+| MCP servers | `call_mcp_tool` (+ resource helpers if present) | Read MCP tool descriptors before calling |
+| Plan mode | `SwitchMode` | When the product exposes a planning mode |
+| Images | `GenerateImage` | Only when the user asks for generated images |
+| Notebooks | `EditNotebook` | `.ipynb` cell edits |
+| Lint diagnostics | `ReadLints` | After substantive edits when available |
+
+**Browser:** often MCP tools (for example `cursor-ide-browser`) with names like `browser_snapshot`, `browser_navigate`—follow the server’s schema.
+
+**Parallel batching:** issue **multiple independent tool calls in one assistant turn** when the runtime allows it (same idea as batched parallel execution).
+
+**Other Cursor surfaces** (CLI, older builds, API): names may differ (`ReadFile`, `ApplyPatch`, `Subagent`, etc.). The **exact tool list in the current session always wins**—same principle as `model-compatibility.mdc`.
 
 ## Read and Search Guidance
 
 - Prefer direct read/search tools over shell equivalents.
-- Batch independent reads and searches with `multi_tool_use.parallel`.
+- Batch independent reads and searches in one turn when the session allows parallel calls.
 - Use `SemanticSearch` for "how/where/what handles this?" questions, not exact symbol lookups.
 
 ## Editing Guidance
 
-- Read the file first.
-- Use `ApplyPatch` for focused edits.
+- Read the file first (`Read`).
+- Use `StrReplace` for focused in-file edits; use `Write` for new files or full rewrites when patch context is awkward.
 - Keep edits coherent; avoid thrashing the same file with many tiny changes.
 - Re-read or verify after editing.
 
@@ -58,7 +80,7 @@ Before starting dev servers or watchers, check whether one is already running.
 
 ## Browser Guidance
 
-When browser tools exist:
+When browser tools exist (including Cursor’s integrated browser in supported builds):
 
 ```text
 1. Check tabs
@@ -77,13 +99,13 @@ Do not promise a browser-only or canvas-style deliverable until you have confirm
 - If an MCP server exposes resources instead of action tools, use the resource functions the environment provides.
 - Keep repo guidance generic enough to survive tool and server renames.
 
-## Subagent Guidance
+## Task and subagent guidance
 
-Use `Subagent` for isolated research, broad exploration, debugger or verifier passes, or other branches that would otherwise pollute the main context.
+In Composer-style agents the delegation tool is usually **`Task`**, with a `subagent_type` and prompt (see the live schema). Use it for isolated research, broad exploration, debugger or verifier passes, or branches that would otherwise pollute the main context.
 
-When multiple subagent tasks are truly independent:
-- launch them concurrently in the same assistant turn instead of queueing them one by one
-- give each subagent a distinct scope, expected output, and stopping point
+When multiple delegations are truly independent:
+- launch them concurrently in the same assistant turn when the schema allows
+- give each run a distinct scope, expected output, and stopping point
 - keep one synthesis step in the main thread after they return
 - avoid overlap that makes two agents inspect the same surface without a reason
 
@@ -105,15 +127,15 @@ Parallelize only when calls are independent:
 - multiple reads
 - unrelated searches
 - independent research tracks
-- separate subagent investigations with different scopes
+- separate `Task` / subagent investigations with different scopes
 
-For subagents specifically:
+For `Task` specifically:
 
 ```text
 1. Split the work into independent slices
-2. Launch multiple Subagent calls in one message when they do not depend on each other
+2. Launch multiple Task calls in one message when they do not depend on each other
 3. Wait for all results
 4. Synthesize centrally before acting
 ```
 
-Do not parallelize dependent edits or steps that require previous outputs, and do not default to serial subagent launches when a parallel batch is possible.
+Do not parallelize dependent edits or steps that require previous outputs, and do not default to serial Task launches when a parallel batch is possible.

--- a/.cursor/rules/model-compatibility.mdc
+++ b/.cursor/rules/model-compatibility.mdc
@@ -42,7 +42,7 @@ The most common failures are:
 4. Verify with follow-up reads, build, tests, browser checks, or shell output
 ```
 
-If the environment offers `ApplyPatch`, prefer it for focused edits.
+If the environment offers a patch or search-replace edit tool, prefer it for focused edits (Composer-style agents often expose `StrReplace`; other surfaces may use `ApplyPatch` or similar).
 
 ## Version Handling
 

--- a/.cursor/rules/tool-discovery.mdc
+++ b/.cursor/rules/tool-discovery.mdc
@@ -13,8 +13,9 @@ Inventory the current surface in this order:
 
 1. direct tools exposed in the prompt
 2. browser or IDE-native tools exposed in the prompt
-3. MCP tools and resources with their current schemas
-4. web docs only when discovery or versions still remain unclear
+3. **Cursor Marketplace** (or team marketplace) plugins already installed—same schema-first rules as other MCPs; discover tools and resources from each plugin’s descriptors before calling
+4. MCP tools and resources with their current schemas (including project-configured servers)
+5. web docs only when discovery or versions still remain unclear
 
 ## Schema-First Use
 

--- a/.cursor/skills/deep-research/SKILL.md
+++ b/.cursor/skills/deep-research/SKILL.md
@@ -19,11 +19,11 @@ Conduct thorough, multi-step research using an iterative loop of search, compres
 
 Before starting, calibrate depth to the question:
 
-| Tier | When | Searches | Subagents | Output |
-|------|------|----------|-----------|--------|
+| Tier | When | Searches | Delegation (`Task`) | Output |
+|------|------|----------|---------------------|--------|
 | **Quick** | Focused factual question, single concept | 2-3 | None | Concise answer with sources |
 | **Standard** | Multi-faceted topic, comparison, how-something-works | 5-8 | None | Structured analysis with sections |
-| **Exhaustive** | Comprehensive survey, architecture decision, landscape review | 10+ | Parallel `Subagent` investigations | Full report with citations |
+| **Exhaustive** | Comprehensive survey, architecture decision, landscape review | 10+ | Parallel `Task` investigations | Full report with citations |
 
 ```
 Calibration:
@@ -54,7 +54,7 @@ Immediately classify the research request before any searching.
 | Source | When to use |
 |--------|-------------|
 | `WebSearch` + `WebFetch` | General knowledge, current events, library docs, community solutions |
-| `SemanticSearch` + `rg` + `ReadFile` | Codebase-specific questions, internal patterns, project architecture |
+| `SemanticSearch` + `Grep` + `Read` | Codebase-specific questions, internal patterns, project architecture |
 | Mixed | "How should we implement X?" (need both external best practices and internal conventions) |
 
 **Step 3 -- Generate a one-paragraph research brief:**
@@ -97,7 +97,7 @@ TodoWrite(todos=[
 ], merge=false)
 ```
 
-**For Exhaustive tier**, evaluate which sub-queries are independent (can run in parallel via `Subagent`) vs. dependent (must run sequentially because results inform next query).
+**For Exhaustive tier**, evaluate which sub-queries are independent (can run in parallel via `Task`) vs. dependent (must run sequentially because results inform next query).
 
 ---
 
@@ -117,16 +117,16 @@ This is the core iterative cycle. Execute it per sub-query.
 **Codebase research pattern:**
 ```
 1. SemanticSearch(query="[natural language question]", target_directories=[relevant dir])
-2. If results point to specific files, read them with `ReadFile`
-3. If searching for exact symbols, use `rg`
+2. If results point to specific files, read them with `Read`
+3. If searching for exact symbols, use `Grep`
 4. Compress: extract the pattern/answer, not the full file contents
 ```
 
-**Parallel subagent pattern (Exhaustive tier only):**
+**Parallel Task pattern (Exhaustive tier only):**
 ```
-Launch up to 3 parallel `Subagent` investigations for independent sub-queries:
+Launch up to 3 parallel `Task` investigations for independent sub-queries:
 
-Subagent(
+Task(
   subagent_type="generalPurpose",
   model="fast",
   readonly=true,
@@ -258,7 +258,7 @@ Update TodoWrite to mark all research sub-queries and synthesis as completed.
 This skill uses only Cursor-native tools and plain behavioral instructions:
 - No model-specific prompting syntax
 - No assumptions about thinking/reasoning format
-- All tool references (`WebSearch`, `WebFetch`, `SemanticSearch`, `rg`, `ReadFile`, `Subagent`, `TodoWrite`) are Cursor-standard
+- Tool names in this skill are **illustrative**; **use the exact identifiers and schemas** from the active session. In Composer-style Cursor agents you will typically see `Read`, `Grep`, `StrReplace`, `Task` (delegation), `WebSearch`, `WebFetch`, `SemanticSearch`, `TodoWrite`, and others—names differ in older docs or other products (`ReadFile`, `ApplyPatch`, `Subagent`, etc.)
 - Reflection happens in whatever reasoning mechanism the model supports
 
 The iterative search-compress-reflect loop is a behavioral pattern, not a code construct. Any model that can call tools and reason about results can execute it.

--- a/.cursor/skills/deep-research/reference.md
+++ b/.cursor/skills/deep-research/reference.md
@@ -36,11 +36,11 @@ Tier: Standard (technical depth needed, but focused topic)
 ```
 Sub-queries (hypothesis-driven):
   Hypothesis A: Dependency changes increased install time
-    -> use `rg` for package or lockfile references in recent changes
+    -> use `Grep` for package or lockfile references in recent changes
   Hypothesis B: New test suite added significant runtime
     -> SemanticSearch for test configuration changes
   Hypothesis C: CI runner resource constraints changed
-    -> read CI config files with `ReadFile`, then search targeted symbols with `rg`
+    -> read CI config files with `Read`, then search targeted symbols with `Grep`
 
 Strategy: Parallel hypotheses, then sequential deep-dive on most likely
 Tier: Standard (codebase-focused, bounded scope)
@@ -59,7 +59,7 @@ Sub-queries:
 
 Strategy: Parallel (all independent), then sequential follow-ups on gaps
 Tier: Exhaustive (broad landscape, many dimensions)
-Subagent plan: launch 3 parallel `Subagent` investigations for queries 1-3, then 3 more for 4-6
+Task plan: launch 3 parallel `Task` investigations for queries 1-3, then 3 more for 4-6
 ```
 
 ### Fact-check: "Does HTTP/3 always outperform HTTP/2?"
@@ -110,7 +110,7 @@ Is the scope broad (landscape, options, overview)?
 |---------------|---------------|-----------------|-------|
 | **Comparison** | Official docs, benchmarks | Community blog posts, HN/Reddit threads | Marketing pages |
 | **Explanation** | Academic papers, official docs, RFCs | Tutorials, conference talks | Stack Overflow answers (often outdated) |
-| **Investigation** | Codebase (`rg`, `ReadFile`, `SemanticSearch`) | Git history, CI logs | Generic web results |
+| **Investigation** | Codebase (`Grep`, `Read`, `SemanticSearch`) | Git history, CI logs | Generic web results |
 | **Survey** | Industry reports, official announcements | Developer surveys, trend analyses | Individual opinion posts |
 | **Fact-check** | Primary sources (papers, official docs) | Independent benchmarks | Social media, forums |
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 [![Stars](https://img.shields.io/github/stars/madebyaris/advance-minimax-m2-cursor-rules?style=flat-square)](https://github.com/madebyaris/advance-minimax-m2-cursor-rules/stargazers)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg?style=flat-square)](LICENSE)
-[![Cursor 2.6](https://img.shields.io/badge/Tested-Cursor%202.6-blue?style=flat-square)](https://cursor.com/changelog)
+[![Cursor 3](https://img.shields.io/badge/Tested-Cursor%203-blue?style=flat-square)](https://cursor.com/blog/cursor-3)
 [![MiniMax M2.7](https://img.shields.io/badge/MiniMax-M2.7-purple?style=flat-square)](https://platform.minimax.io)
 [![Any Model](https://img.shields.io/badge/Compatible-Any%20Model-green?style=flat-square)](#model-compatibility)
 


### PR DESCRIPTION
…lity with Cursor 3 and update badge links. Enhance agent orchestration and team rules with new guidance on parallel sessions, local and cloud workflows, and marketplace plugins. Adjust tool references to align with current naming conventions, ensuring clarity and consistency across all documentation.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update docs for Cursor 3: refresh README badge and revise rules/skills to reflect parallel agent sessions, local vs cloud workflows, marketplace plugins, and current tool names (`Task`, `Read`, `Grep`, `StrReplace`). This keeps guidance accurate and consistent with the Cursor 3 Agents experience.

- **New Features**
  - Added guidance for parallel sessions and sidebar orchestration; emphasize independent workstreams and single-point synthesis.
  - Documented local vs cloud agent handoffs and when to use each.
  - Included marketplace plugin usage in MCP optimization and tool discovery (schema-first, inventory before use).
  - Updated tool map to Composer-style names (`Read`, `Grep`, `SemanticSearch`, `StrReplace`, `Write`, `Task`, `call_mcp_tool`, etc.) and integrated browser workflow.
  - Revised deep-research skill and references to use current tool names and `Task` for delegation.
  - README badge now shows Cursor 3.

- **Migration**
  - Use `Task` where available instead of `Subagent`; batch independent calls in one turn.
  - Prefer `Read`/`Grep`/`StrReplace` over `ReadFile`/`rg`/`ApplyPatch` when exposed in the session.
  - In handoffs, name the repo/workspace; avoid parallel edits to the same files.
  - Use integrated browser tools when present; verify locally for environment-specific claims.

<sup>Written for commit c9388a9dc8dea1a10dd0704f36e5e10c23e410c9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

