### PR TITLE
Update documentation for MiniMax M3 and Cursor 3: Revise CONTRIBUTING…

### DIFF
--- a/.cursor/rules/agent-teams.mdc
+++ b/.cursor/rules/agent-teams.mdc
@@ -1,9 +1,9 @@
 ---
-description: "MiniMax M2.7 agent teams: role boundaries, handoffs, escalation, and serial vs parallel team structure."
+description: "MiniMax M3 + Cursor 3 agent teams: role boundaries, multi-environment handoffs, /best-of-n as a team pattern, escalation, and serial vs parallel team structure."
 alwaysApply: false
 ---
 
-# Agent Teams
+# Agent Teams (M3 + Cursor 3)
 
 Use this rule when the work is best handled by multiple agents or explicitly separated roles.
 
@@ -15,7 +15,16 @@ Use this rule when the work is best handled by multiple agents or explicitly sep
 
 ## Multiple concurrent Cursor sessions
 
-Cursor 3 can run **several agent sessions in parallel** (for example from the sidebar). The same rules apply as for parallel roles or subagent branches: use parallel sessions only for **independent** workstreams, keep **non-overlapping ownership** of files and decisions, and **serialize** anything that would race the same artifact. More sessions visible at once does not make conflicting edits safer.
+Cursor 3 can run **several agent sessions in parallel** (for example from the Agents Window sidebar, or kicked off from mobile, web, Slack, GitHub, Linear). The same rules apply as for parallel roles or subagent branches: use parallel sessions only for **independent** workstreams, keep **non-overlapping ownership** of files and decisions, and **serialize** anything that would race the same artifact. More sessions visible at once does not make conflicting edits safer.
+
+## Multi-Environment Teams
+
+When a single team spans environments (some roles local, some in `/worktree`, some in cloud, some over SSH):
+
+- The handoff contract must name the **environment** per role — local, worktree, cloud, or SSH — and the **model** per role.
+- Choose environments to remove file-system races: if two roles may touch the same artifact, pin both to the same isolated worktree or serialize the touch.
+- Prefer `/worktree` for any role whose output will be reviewed and possibly discarded. Prefer `cloud` for any role whose value is "keep working while I am away."
+- When one role's output feeds another role in a different environment, the handoff payload should include the file paths, branch, and any required state — not just a prose summary.
 
 ## Handoff Contract
 
@@ -23,6 +32,7 @@ Every handoff should state:
 
 - current goal
 - **which repo or workspace root** when more than one is in play
+- **environment** (local / worktree / cloud / SSH) and **model** (e.g. `MiniMax-M3`, `composer-2`, `auto`)
 - files, dirs, or questions owned
 - findings or artifacts produced
 - open risks or assumptions
@@ -34,21 +44,36 @@ Every handoff should state:
 - Use serial teams when one role depends on another role's findings.
 - If two agents may touch the same file or decision, centralize that step instead of racing them.
 
+## /best-of-n as a Team Pattern
+
+For decisions where a second opinion is cheap insurance (architecture choice, design parity, risky refactor, choosing between two valid approaches), treat `/best-of-n` as a team pattern:
+
+```text
+1. Define the question and the deliverable shape
+2. Run the same prompt across 2-4 models in parallel worktrees
+3. Read each result centrally
+4. Pick the strongest, merge complementary ideas, or escalate to the user with the comparison
+```
+
+The "team" is the synthesis step, not the model run; centralize it.
+
 ## Challenge And Review
 
 - At least one role should challenge assumptions, edge cases, or weak evidence on non-trivial work.
 - Reviewer or verifier roles should critique the work, not merely restate it.
 - Keep disagreement evidence-based and scoped to the task.
+- A verifier reviewing visual work should re-read the actual post-change frame, not rely on a prose description; that is `multimodal-grounded` review.
 
 ## Human Escalation
 
 Escalate to the user when:
-
 - a branch changes architecture or product direction
 - safety, destructive actions, or irreversible changes appear
 - two valid team recommendations lead to meaningfully different outcomes
+- `/best-of-n` returns a near-tie that needs human taste
 
 ## Closeout
 
 - Synthesize in the main thread before acting on team output.
 - Final user-facing claims must follow the always-on status and verification contract.
+- Include the environment, the model, and the relevant evidence (including `multimodal-grounded` for visual claims) in the closeout.

--- a/.cursor/rules/cursor-agent-orchestration.mdc
+++ b/.cursor/rules/cursor-agent-orchestration.mdc
@@ -1,28 +1,30 @@
 ---
-description: "Cursor orchestration guide: when to plan, when to delegate, and how to keep multi-step work coherent."
+description: "Cursor 3 orchestration guide: when to plan, when to delegate, multi-environment handoffs, /best-of-n, and Await for long-running branches."
 alwaysApply: false
 ---
 
-# Cursor Agent Orchestration
+# Cursor 3 Agent Orchestration
 
 Use this rule for deep or exhaustive tasks where coordination matters more than raw implementation speed.
 
 ## Core Idea
 
-The main agent should own synthesis. Plans, subagents, and task tracking exist to reduce context load and make large work safer.
+The main agent should own synthesis. Plans, subagents, and task tracking exist to reduce context load and make large work safer. On M3, the main agent also owns the 1M-context loader — see `minimax-m3-long-context`.
 
-## Local and cloud sessions (optional)
+## Local, worktree, cloud, and SSH sessions
 
-Cursor 3 emphasizes moving work between **local** and **cloud** agent sessions. Treat this as workflow guidance, not a requirement:
+Cursor 3 emphasizes moving work between execution environments inside the Agents Window. Treat this as workflow guidance, not a requirement:
 
 - Prefer **local** when you need fast edit–run–debug loops, full filesystem access, or machine-specific verification.
-- Consider **cloud** when a task should keep running while you are away, or when you want continuation without tying up the local machine—then **hand back to local** to validate on the real environment when claims are environment-specific.
+- Prefer **/worktree** (isolated git worktree) when the task must not collide with the main tree, when you are running parallel branches, or when you want a disposable environment.
+- Consider **cloud** when a task should keep running while you are away, or when you want continuation without tying up the local machine — then **hand back to local** to validate on the real environment when claims are environment-specific.
+- Consider **SSH** when the runtime is on a remote host (e.g. an edge box, a build farm, a server) and the work needs direct access.
 
-Handoffs should still use explicit goals, owned paths, and what was verified (see `agent-teams.mdc`).
+Handoffs should still use explicit goals, owned paths, environment, model, and what was verified (see `agent-teams.mdc`).
 
 ## Parallel sessions and the sidebar
 
-Cursor 3 can show **many agent sessions** at once (including from other surfaces). That mirrors the idea of concurrent **`Task`** / subagent delegation: only parallelize **independent** slices, merge results in one synthesis step, and avoid two sessions racing the same files. The UI makes parallelism easier; it does not remove the need for clear ownership.
+Cursor 3 can show **many agent sessions** at once (including from other surfaces — mobile, web, Slack, GitHub, Linear). That mirrors the idea of concurrent **`Task`** / subagent delegation: only parallelize **independent** slices, merge results in one synthesis step, and avoid two sessions racing the same files. The UI makes parallelism easier; it does not remove the need for clear ownership, non-overlapping paths, and one synthesis step.
 
 ## When to Plan
 
@@ -37,7 +39,7 @@ Use the environment's active planning workflow or mode when it exists instead of
 
 ## When to Use Task (subagents)
 
-In Composer-style Cursor agents the tool is usually **`Task`** (subagent-style delegation; types such as explore, debugger, verifier—see the live schema). Use it when:
+In Composer-style Cursor agents the tool is usually **`Task`** (subagent-style delegation; types such as explore, debugger, verifier — see the live schema). Use it when:
 - repo exploration is broad and would pollute main context
 - independent investigations can run in parallel
 - a verifier or debugger pass would help
@@ -47,15 +49,44 @@ Avoid delegation overhead for instant or light work.
 
 When several independent branches exist, do not launch them serially by habit. Launch multiple `Task` calls together with separate scopes and merge their results in the main thread.
 
+## /best-of-n as an Orchestration Primitive
+
+For high-stakes decisions (architecture, refactor approach, design parity), the `/best-of-n` command runs the same prompt across 2–4 models in parallel worktrees and then compares outcomes.
+
+A small workflow for using it well:
+
+```text
+1. Pick 2-4 models (mix is fine: composer-2 + MiniMax-M3 + a third)
+2. Write one bounded prompt that names the question, the constraint, and the deliverable shape
+3. Run /best-of-n in isolated worktrees
+4. Read each result centrally; tag them with the model
+5. Pick the strongest, merge complementary ideas, or escalate to the user with the comparison
+```
+
+Keep prompts bounded. `/best-of-n` is wasted when the prompt is vague.
+
+## Await for Long-Running Branches
+
+For dev servers, watchers, build jobs, parallel subagents, or CLI tools that take seconds-to-minutes, do not poll. Use the `Await` tool to wait for a background shell/subagent or a specific output token (`Ready`, `Compiled`, `Error`).
+
+```text
+1. Start the long-running work in the background
+2. Await the result or a specific output string
+3. If it fails, Await the error message and form the next hypothesis
+```
+
+This prevents the "waste 30s polling" failure mode and keeps the main thread responsive on M3.
+
 ## Delegation Pattern
 
 ```text
 1. Define the slices
 2. Delegate only independent work
 3. Launch independent subagents concurrently when possible
-4. Read subagent summaries
-5. Synthesize decisions in the main thread
-6. Implement and verify centrally
+4. Await long-running branches
+5. Read subagent summaries
+6. Synthesize decisions in the main thread
+7. Implement and verify centrally
 ```
 
 ## Parallel Delegation Rules
@@ -66,6 +97,7 @@ When several independent branches exist, do not launch them serially by habit. L
 - Do not split work so finely that coordination costs more than the saved time.
 - If one branch depends on another, keep it sequential.
 - If two subagents may overlap, assign different directories, files, or questions.
+- When you can name the environment (local/worktree/cloud/SSH) and the model per subagent, do — it makes the synthesis cleaner.
 
 Parallel subagents are best for research and analysis. Centralize edits and final verification unless there is a strong reason to delegate them.
 
@@ -91,13 +123,13 @@ Verify
 Broaden carefully
 ```
 
-For exhaustive work, break the task into independently verifiable milestones rather than broad abstract epics.
+For exhaustive work, break the task into independently verifiable milestones rather than broad abstract epics. On M3, also load `minimax-m3-long-context` once the milestones cross ~200K tokens of input.
 
 ## Verification During Orchestration
 
 Do not postpone all checks to the end. Verify per phase:
 - after code changes, run the smallest relevant command
-- after UI changes, use browser checks when needed
+- after UI changes, use browser checks or `multimodal-grounded` re-reads of post-change frames
 - after a major feature phase, run broader validation
 
 Use the **diff / review surface** in Cursor when it helps you stage, review, and ship; keep claims aligned with the always-on status and verification rule regardless of UI.

--- a/.cursor/rules/cursor-mcp-optimization.mdc
+++ b/.cursor/rules/cursor-mcp-optimization.mdc
@@ -1,18 +1,18 @@
 ---
-description: "Cursor MCP optimization: browser, Figma, and Cloudflare tools with direct action patterns."
+description: "Cursor 3 MCP optimization: browser, Figma, and Cloudflare tools, MCP Apps structured content, and direct action patterns."
 alwaysApply: false
 ---
 
-# Cursor MCP Optimization
+# Cursor 3 MCP Optimization
 
-Direct guidance for Cursor's MCP tools. Use the right tool for each job.
+Direct guidance for Cursor 3's MCP tools. Use the right tool for each job.
 
 ## Browser Tools (cursor-ide-browser)
 
 **Always do before any interaction:**
 ```
-1. browser_tabs with action: "list" → check current tabs/URLs
-2. browser_snapshot → get current page structure and refs
+1. browser_tabs with action: "list" -> check current tabs/URLs
+2. browser_snapshot -> get current page structure and refs
 ```
 
 **Interaction pattern:**
@@ -43,14 +43,15 @@ Direct guidance for Cursor's MCP tools. Use the right tool for each job.
 ```
 
 **URL parsing:**
-- `figma.com/design/:fileKey/:fileName?node-id=:nodeId` → convert "-" to ":" in nodeId
-- `figma.com/board/:fileKey/:fileName` → FigJam, use get_figjam
-- `figma.com/make/:makeFileKey/:makeFileName` → use makeFileKey
+- `figma.com/design/:fileKey/:fileName?node-id=:nodeId` -> convert "-" to ":" in nodeId
+- `figma.com/board/:fileKey/:fileName` -> FigJam, use get_figjam
+- `figma.com/make/:makeFileKey/:makeFileName` -> use makeFileKey
 
 **When designer provides screenshots:**
 - Use get_screenshot for visual verification
 - Translate Figma design tokens to project's token system
 - Never copy exact Figma hex values without checking project palette
+- For M3 multimodal parity, the design screenshot is the contract — cite the file path in the report
 
 ## Cloudflare Tools
 
@@ -68,6 +69,15 @@ Direct guidance for Cursor's MCP tools. Use the right tool for each job.
 
 **MCP auth:** If a Cloudflare MCP server has `mcp_auth`, call it before using tools.
 
+## MCP Apps Structured Content (Cursor 3)
+
+Cursor 3 supports **MCP Apps structured content** — tools can now return richer structured outputs (typed objects, lists, tables) instead of prose blobs.
+
+- When a tool returns structured content, **prefer the structured form** over reconstructing from prose.
+- Surface the structured result faithfully in the report — do not paraphrase the shape.
+- A few plugin families (Vercel, Linear, Cloudflare) already return structured outputs of this kind; check the descriptor before assuming a tool returns plain text.
+- If the runtime supports it, render tabular or nested results as a canvas or table, not as a markdown dump.
+
 ## MCP General Rules
 
 ```
@@ -75,16 +85,19 @@ Direct guidance for Cursor's MCP tools. Use the right tool for each job.
 2. Use exact parameter names from the schema
 3. If tool unavailable, say so and use next best exposed path
 4. Do not infer hidden parameters or old API versions
+5. If the tool returns structured content, use the structured form rather than the prose form
 ```
 
 ## Marketplace plugins
 
-Plugins installed from the [Cursor Marketplace](https://cursor.com/marketplace) extend agents with MCPs, skills, and related capabilities. Treat them like any other MCP surface: **inventory** what the session exposes, **read descriptors/schemas** before first use, then call the smallest valid tool—same as in `tool-discovery.mdc`.
+Plugins installed from the [Cursor Marketplace](https://cursor.com/marketplace) extend agents with MCPs, skills, and related capabilities. Treat them like any other MCP surface: **inventory** what the session exposes, **read descriptors/schemas** before first use, then call the smallest valid tool — same as in `tool-discovery.mdc`.
+
+**Rollout caveat (Cursor 3):** third-party plugin imports now **default to off for Enterprises** when unset, while preserving explicit Admin overrides. If you are working in an Enterprise workspace, confirm the plugin import policy with the Admin before relying on a marketplace plugin.
 
 ## Capability Mapping Checklist
 
 Before acting, confirm:
 - [ ] Direct native tool exists for this action
-- [ ] MCP tool exists with current schema
+- [ ] MCP tool exists with current schema (and structured-content support if relevant)
 - [ ] Browser interaction confirmed via snapshot
 - [ ] Fallback path identified if primary fails

--- a/.cursor/rules/cursor-tools-mastery.mdc
+++ b/.cursor/rules/cursor-tools-mastery.mdc
@@ -1,18 +1,20 @@
 ---
-description: "Cursor runtime guide: choose the right tool, prefer direct tools, and keep execution parallel where safe."
+description: "Cursor 3 runtime guide: choose the right tool, prefer direct tools, use /worktree, /best-of-n, and Await where they fit, and keep execution parallel where safe."
 alwaysApply: false
 ---
 
-# Cursor Tools Mastery
+# Cursor 3 Tools Mastery
 
-Keep durable behavior in the core rule. Use this file for current Cursor tool-selection patterns.
+Keep durable behavior in the core rule. Use this file for current Cursor 3 tool-selection patterns and the Agents Window surface.
 
 ## Cursor 3 workspace
 
-In Cursor 3, agent work is centered in the **Agents** experience. Open it from the command palette: **Agents Window** (for example `Cmd+Shift+P` on macOS, as described in the [Cursor 3 announcement](https://cursor.com/blog/cursor-3)).
+In Cursor 3, agent work is centered in the **Agents Window**. Open it from the command palette: `Cmd+Shift+P -> Agents Window` on macOS (per the [Cursor 3 announcement](https://cursor.com/blog/cursor-3)). The classic three-pane editor is still available; switch between them at any time.
 
-- **Multi-workspace / multi-repo:** the UI can surface several workspaces at once. Name the repo or root path when handing off work, opening files, or running commands so edits land in the intended tree.
-- **Integrated browser:** prefer the IDE’s built-in browser for local UI verification when it is exposed in your session; it matches the “snapshot-first” flow in Browser Guidance below.
+- **Multi-workspace / multi-repo:** the Agents Window can surface several workspaces at once. Name the repo or root path when handing off work, opening files, or running commands so edits land in the intended tree.
+- **Per-session execution environment:** each agent tab picks its own environment — local working tree, isolated worktree (`/worktree`), cloud sandbox, or remote SSH. State the environment in the handoff contract; it is the unit of isolation.
+- **Per-session model picker:** the model picker lives in the agent tab header (e.g. `composer-2`, `MiniMax-M3`, `auto`). Name the model in the handoff contract.
+- **Integrated browser:** prefer the IDE's built-in browser for local UI verification when it is exposed in your session; it matches the "snapshot-first" flow in Browser Guidance below.
 
 ## Golden Rule
 
@@ -27,13 +29,13 @@ Validate with the lightest useful verification
 
 ## Default Tool Map
 
-**Composer 2 / Cursor agent (typical names in current desktop agents):** the session usually exposes something close to:
+**Cursor 3 / Composer-style agents (typical names in current desktop agents)** — the session usually exposes something close to:
 
-| Step | Tool name | Notes |
-|------|-----------|--------|
+| Step | Tool / command | Notes |
+|------|----------------|-------|
 | Read a path | `Read` | Prefer over shell `cat`/`sed` |
 | Search by pattern | `Grep` | Ripgrep-backed; use for exact symbols and strings |
-| Search by meaning | `SemanticSearch` | “Where does X happen?” not exact text |
+| Search by meaning | `SemanticSearch` | "Where does X happen?" not exact text |
 | List paths | `Glob` | File discovery by pattern |
 | Edit in place | `StrReplace` | Surgical edits; read the file first |
 | Create or replace whole file | `Write` | Use when there is no stable old_string to patch |
@@ -42,24 +44,40 @@ Validate with the lightest useful verification
 | Web | `WebSearch`, `WebFetch` | |
 | Ask user | `AskQuestion` | |
 | Track steps | `TodoWrite` | |
-| Delegate branch work | `Task` | Subagent-style runs (types such as explore, debugger, verifier—see schema) |
+| Delegate branch work | `Task` | Subagent-style runs (types such as explore, debugger, verifier — see schema) |
+| Wait for background work | `Await` | Wait for a background shell, subagent, or a specific output token (e.g. `Ready`, `Error`) |
+| Isolated worktree | `/worktree` | Run a session in its own git worktree so concurrent edits do not collide |
+| Parallel model compare | `/best-of-n` | Run the same task across N models in parallel worktrees, then compare |
 | MCP servers | `call_mcp_tool` (+ resource helpers if present) | Read MCP tool descriptors before calling |
 | Plan mode | `SwitchMode` | When the product exposes a planning mode |
 | Images | `GenerateImage` | Only when the user asks for generated images |
 | Notebooks | `EditNotebook` | `.ipynb` cell edits |
 | Lint diagnostics | `ReadLints` | After substantive edits when available |
+| Multimodal inputs | `Read` against attached image/video paths | M3 native multimodal — treat as first-class inputs |
 
-**Browser:** often MCP tools (for example `cursor-ide-browser`) with names like `browser_snapshot`, `browser_navigate`—follow the server’s schema.
+**Browser:** often MCP tools (for example `cursor-ide-browser`) with names like `browser_snapshot`, `browser_navigate` — follow the server's schema.
 
-**Parallel batching:** issue **multiple independent tool calls in one assistant turn** when the runtime allows it (same idea as batched parallel execution).
+**Parallel batching:** issue **multiple independent tool calls in one assistant turn** when the runtime allows it.
 
-**Other Cursor surfaces** (CLI, older builds, API): names may differ (`ReadFile`, `ApplyPatch`, `Subagent`, etc.). The **exact tool list in the current session always wins**—same principle as `model-compatibility.mdc`.
+**Other Cursor surfaces** (CLI, older builds, API): names may differ (`ReadFile`, `ApplyPatch`, `Subagent`, etc.). The **exact tool list in the current session always wins** — same principle as `model-compatibility.mdc`.
+
+## Pick The Right Surface (Cursor 3)
+
+| Need | Best fit |
+|------|----------|
+| Trivial localized edit | IDE inline edit |
+| Multi-file feature in one repo | Single agent session in the Agents Window |
+| Risky exploration, parallel branches, anything that must not collide with the main tree | `/worktree` (isolated git worktree) |
+| High-stakes decision (design, architecture, refactor) where you want a second opinion | `/best-of-n` (run across 2–4 models, then pick or merge) |
+| Long-running shell, subagent, or CLI that takes seconds-to-minutes | `Await` on the background job, or a specific output token |
+| Work that should keep running while you walk away | Cloud session, then hand back to local when environment-specific proof is needed |
 
 ## Read and Search Guidance
 
 - Prefer direct read/search tools over shell equivalents.
 - Batch independent reads and searches in one turn when the session allows parallel calls.
 - Use `SemanticSearch` for "how/where/what handles this?" questions, not exact symbol lookups.
+- For long files or large repos, prefer targeted `Grep` or slice-sized `Read` over full re-ingest; see `minimax-m3-long-context` for the M3 1M-context version of this.
 
 ## Editing Guidance
 
@@ -67,6 +85,7 @@ Validate with the lightest useful verification
 - Use `StrReplace` for focused in-file edits; use `Write` for new files or full rewrites when patch context is awkward.
 - Keep edits coherent; avoid thrashing the same file with many tiny changes.
 - Re-read or verify after editing.
+- For UI changes, re-read the post-change screenshot/frame when one is available and cite the path in the report.
 
 ## Shell Guidance
 
@@ -76,11 +95,13 @@ Use `Shell` for:
 - git inspection
 - long-running verification commands when no dedicated tool exists
 
-Before starting dev servers or watchers, check whether one is already running.
+Before starting dev servers or watchers:
+- check the terminals folder for an existing one
+- when one is started, `Await` its output token (`Ready`, `Compiled`, etc.) instead of polling
 
 ## Browser Guidance
 
-When browser tools exist (including Cursor’s integrated browser in supported builds):
+When browser tools exist (including Cursor's integrated browser in supported builds):
 
 ```text
 1. Check tabs
@@ -97,6 +118,7 @@ Do not promise a browser-only or canvas-style deliverable until you have confirm
 
 - Prefer direct tools exposed in the prompt over wrapper APIs.
 - If an MCP server exposes resources instead of action tools, use the resource functions the environment provides.
+- **MCP Apps structured content** (new in Cursor 3): when a tool returns structured content, prefer the structured form over prose dumping; surface it in the report faithfully.
 - Keep repo guidance generic enough to survive tool and server renames.
 
 ## Task and subagent guidance
@@ -109,10 +131,13 @@ When multiple delegations are truly independent:
 - keep one synthesis step in the main thread after they return
 - avoid overlap that makes two agents inspect the same surface without a reason
 
+For long-running delegations, `Await` the subagent result instead of polling.
+
 Good parallel split examples:
 - frontend investigation vs backend investigation
 - version research vs codebase pattern search
 - debugger pass vs verifier pass
+- `/best-of-n` style: same prompt to 2–3 models in isolated worktrees
 
 Bad parallel split examples:
 - two agents editing the same file
@@ -134,7 +159,7 @@ For `Task` specifically:
 ```text
 1. Split the work into independent slices
 2. Launch multiple Task calls in one message when they do not depend on each other
-3. Wait for all results
+3. Wait for all results (use Await for long-running ones)
 4. Synthesize centrally before acting
 ```
 

--- a/.cursor/rules/minimax-m3-core.mdc
+++ b/.cursor/rules/minimax-m3-core.mdc
@@ -1,19 +1,22 @@
 ---
-description: "MiniMax M2.7 core behavior: solver loop, code discipline, scope control, truthful tool use, scaffold discipline, and concise progress."
+description: "MiniMax M3 core behavior: solver loop, code discipline, scope control, truthful tool use, scaffold discipline, long-context discipline, multimodal input discipline, and concise progress."
 alwaysApply: true
 ---
 
-# MiniMax M2.7 Core Behavior
+# MiniMax M3 Core Behavior
 
 Use concise operational guidance, not provider persona text.
 
-## M2.7 Specific Capabilities
+## M3 Specific Capabilities
 
-M2.7 has 97% skill adherence and supports iterative self-evolution loops. Leverage these:
-- **Iterative refinement**: Run diagnostic → one fix → re-verify cycles (up to 5 per issue)
-- **Structured skill loading**: When a skill matches the task, follow its workflow exactly
-- **Multilingual**: Code in the user's language; comments/docs in the project's established language
-- **Code security**: Check for exposed secrets, SQL injection, XSS, and auth bypass before suggesting solutions
+M3 (released 2026-06-01) is a generational shift: 1M-token MSA context, native multimodal input (text, image, video), and higher agentic and coding benchmarks (SWE-Bench Pro 59.0, Terminal-Bench 2.1 66.0). Leverage these:
+
+- **1M-token MSA context**: with this much room, the failure mode shifts from "ran out of room" to "kept too much raw output." Decide retention vs. compression per slice; compress after every iteration.
+- **Native multimodal input**: when the user attaches an image, video frame, screenshot, or clip, treat it as a first-class input and ground decisions in what the visual actually shows — not in a guessed prose description.
+- **Higher skill adherence**: structured skill loading still wins. Load only the on-point skill, do not preload the catalog. The whole skill system is built for the model to consult selectively.
+- **Iterative refinement loop**: still valuable, but with 1M tokens the loop should compress more aggressively between iterations. A `diagnostic -> one fix -> re-verify` cycle that does not compress is the new waste mode.
+- **Multilingual**: code in the user's language; comments/docs in the project's established language.
+- **Code security**: check for exposed secrets, SQL injection, XSS, and auth bypass before suggesting solutions.
 
 ## Default Posture
 
@@ -52,6 +55,26 @@ For non-trivial work:
 
 - On long or multi-step work, checkpoint before expanding scope: restate the goal, list files touched, checks already run, and what remains.
 - Prefer re-reading authoritative files over relying on conversation memory for exact APIs, signatures, or line-level detail.
+
+## Long-Context Discipline (M3)
+
+With 1M tokens available, the cost of over-loading context is real. Keep the spine:
+
+- Decide retention vs. compression per slice **before** loading it. Pick: keep verbatim / keep summary / drop.
+- Compress after each iteration. Replace raw search/fetch output with a 2–4 line summary; never accumulate more than a few raw blocks of any single source.
+- Prefer targeted `Grep`, `SemanticSearch`, or a slice-sized `Read` over a full-file re-ingest when a slice answer suffices.
+- Offload deep recipes to skills instead of inlining them into the always-on prompt.
+- For very large work, use the `minimax-m3-long-context` skill to plan the loader and compression cadence.
+
+## Multimodal Input Discipline (M3)
+
+When the user provides an image, video frame, screenshot, mock, or clip:
+
+- Read the file/frame in the current session and base decisions on it. Do not paraphrase a guessed description.
+- Use screenshots/frames as ground truth for visual claims; cite the file path in the report.
+- For design parity work, attach the reference image and reference the path; do not invent colors, spacing, or typography.
+- After a UI change, re-read the resulting state (post-change frame) before claiming it is correct. Do not rely on memory of the pre-change state.
+- For deeper workflow (region citations, multi-frame video, before/after diffing), load the `minimax-m3-multimodal-input` skill.
 
 ## Clarify Only on Real Forks
 
@@ -109,6 +132,8 @@ Run the smallest proving check the repo already defines. When no script exists, 
 | Flutter / Dart | `flutter analyze`, `flutter test` |
 | Swift | `swift build`, `swift test` |
 
+For UI changes, also re-read the resulting screenshot/frame (M3 multimodal input) and state `multimodal-grounded` if the visual matches the claim. For interactive or layout-sensitive work, do a browser or user-surface check.
+
 ### Common traps (all languages)
 
 - Editing from memory instead of re-reading the file
@@ -118,13 +143,14 @@ Run the smallest proving check the repo already defines. When no script exists, 
 - Adding dependencies when the repo already has an equivalent
 - Fixing symptoms in one file without checking callers, tests, or CI
 
-For cross-language architecture (SOLID, patterns, module structure, code review), load the `language-agnostic-patterns` rule when designing abstractions, refactoring, or reviewing diffs. For deeper verification selection, load `minimax-m2-verification`. For infrastructure or mobile manifests, load `devops-infrastructure` or `mobile-cross-platform` when globs match. For UI or 3D visuals, load the matching skill (`anti-slop-design`, `3d-web-experiences`).
+For cross-language architecture (SOLID, patterns, module structure, code review), load the `language-agnostic-patterns` rule when designing abstractions, refactoring, or reviewing diffs. For deeper verification selection, load `minimax-m3-verification`. For infrastructure or mobile manifests, load `devops-infrastructure` or `mobile-cross-platform` when globs match. For UI or 3D visuals, load the matching skill (`anti-slop-design`, `3d-web-experiences`). For very long work, load `minimax-m3-long-context`. For visual-fidelity work backed by screenshots/frames, load `minimax-m3-multimodal-input`.
 
 ## Design Fidelity
 
 - Before generating visuals, identify the intended aesthetic from the task, spec, or existing project and keep new work aligned with it.
 - Do not default to generic, median UI patterns when the project already implies a distinct direction.
 - Respect established design constraints such as banned fonts, required icon style, imagery requirements, motion expectations, and layout consistency.
+- For design parity from a reference mock, treat the image as the contract; cite the file path and read the relevant region before claiming a match.
 
 ## Security And Destructive Preflight
 
@@ -137,6 +163,7 @@ For cross-language architecture (SOLID, patterns, module structure, code review)
 - If you did not verify a claim, say that directly instead of implying certainty.
 - Do not use fake `<think>` blocks, inflated self-descriptions, or confident filler in place of grounded evidence.
 - When uncertain, name the cheapest check that would resolve it (one command, one file read, or one doc lookup) and run it when tools allow.
+- For visual claims, ground in the actual attached image/frame, not in a memory or guessed description; if the user did not attach one and the claim needs it, say so.
 
 ## Communication
 

--- a/.cursor/rules/minimax-m3-self-evolution.mdc
+++ b/.cursor/rules/minimax-m3-self-evolution.mdc
@@ -1,11 +1,11 @@
 ---
-description: "MiniMax M2.7 self-evolution harness: iterative refinement loops, autonomous debugging, and recursive improvement patterns."
+description: "MiniMax M3 self-evolution harness: iterative refinement loops, compress-before-iterate, autonomous debugging, and recursive improvement patterns."
 alwaysApply: false
 ---
 
-# MiniMax M2.7 Self-Evolution Harness
+# MiniMax M3 Self-Evolution Harness
 
-M2.7 has a 97% skill adherence rate and supports autonomous self-improvement through iterative reinforcement learning loops. Use this rule when the task involves debugging, optimization, or recursive code improvement.
+M3 has a 1M-token MSA context and high skill adherence, and supports autonomous self-improvement through iterative reinforcement learning loops. Use this rule when the task involves debugging, optimization, or recursive code improvement.
 
 ## Core Loop
 
@@ -13,13 +13,23 @@ M2.7 has a 97% skill adherence rate and supports autonomous self-improvement thr
 Iterate until evidence shows the problem is solved or the approach is exhausted:
   1. Run the smallest diagnostic check
   2. Read the failure output directly
-  3. Make ONE targeted fix based on evidence
-  4. Re-run the exact check that failed
-  5. If fixed, verify the broader surface
-  6. If not fixed, form new hypothesis from the NEW evidence only
+  3. Compress prior raw evidence that you no longer need (see below)
+  4. Make ONE targeted fix based on evidence
+  5. Re-run the exact check that failed
+  6. If fixed, verify the broader surface
+  7. If not fixed, form a new hypothesis from the NEW evidence only
 ```
 
 Do NOT repeat the same fix twice on the same hypothesis. Do NOT assume the cause without reading the evidence.
+
+## Compress Before Next Iteration (M3)
+
+On M3 the failure mode shifts from "ran out of room" to "ran too many parallel hypotheses without compressing." Before each new iteration:
+
+- Replace raw search/fetch output from previous iterations with a 2–4 line summary.
+- Drop evidence that is no longer relevant to the current hypothesis.
+- Keep one canonical "current best hypothesis" line at the top of your scratchpad.
+- For very large work, use the `minimax-m3-long-context` skill to plan the loader.
 
 ## When to Use This Harness
 
@@ -30,12 +40,14 @@ Do NOT repeat the same fix twice on the same hypothesis. Do NOT assume the cause
 | Fix failing test | Read test → read code → one fix → run test |
 | Investigate unexpected behavior | Log/check → hypothesis → targeted probe |
 | Iterative code improvement | Current state → one improvement → verify |
+| Triage a visual bug from a screenshot | Read the screenshot, form hypothesis, one fix, re-read the post-change frame (`multimodal-grounded`) |
 
 ## Iteration Limits
 
 - **Diagnostic phase**: 3 iterations to identify root cause
 - **Fix phase**: 2 iterations per hypothesis before switching strategy
 - **Overall**: If 5 total iterations pass without progress, summarize evidence and ask
+- **Context check**: if you have run 3+ raw search/fetch operations without compressing, compress before continuing
 
 ## Evidence Rules
 
@@ -44,6 +56,7 @@ Always prefer direct evidence over inference:
 - Test failures: Read the test output
 - Performance: Read the actual measurement
 - Behavior: Read the actual output/log
+- Visual claims: Read the actual attached image/frame, not a memory or guessed description
 
 Never say "likely caused by" without reading the evidence first.
 
@@ -64,3 +77,5 @@ Next action: [specific check to confirm new hypothesis]
 - Do not make multiple changes between diagnostic cycles
 - Do not assume a fix works without re-running the exact check
 - Do not expand scope mid-iteration (finish the loop first)
+- Do not accumulate raw search output across iterations without compressing
+- Do not make a visual-fidelity claim without re-reading the post-change frame

--- a/.cursor/rules/minimax-m3-status-verification.mdc
+++ b/.cursor/rules/minimax-m3-status-verification.mdc
@@ -1,9 +1,9 @@
 ---
-description: "MiniMax M2.7 status and verification contract: exact claim labels, proof matching, and evidence-first closeouts."
+description: "MiniMax M3 status and verification contract: exact claim labels, proof matching, multimodal-grounded visual claims, and evidence-first closeouts."
 alwaysApply: true
 ---
 
-# MiniMax M2.7 Status And Verification
+# MiniMax M3 Status And Verification
 
 Code is not done until it has been proved at the surface the user cares about.
 
@@ -16,6 +16,7 @@ Use explicit status language in updates and closeouts:
 - `unverified`: the work exists but the required proof was not run
 - `blocked`: required progress or proof failed and the task cannot honestly be called done
 - `assumption`: a choice or statement depends on inference rather than direct evidence
+- `multimodal-grounded`: the claim is grounded in an attached image, video frame, screenshot, or design mock that was actually read in the current session (M3 native multimodal input). Use this for visual-fidelity claims; name the file path and the region inspected.
 
 Do not use `done`, `fixed`, `working`, or `resolved` without naming the proof immediately after.
 
@@ -26,6 +27,7 @@ Do not use `done`, `fixed`, `working`, or `resolved` without naming the proof im
 - Separate what you observed from what you infer.
 - If intended verification failed and you fall back to a weaker check, say so explicitly.
 - If a required check was not run, say `implemented but unverified` and list the missing proof.
+- For visual claims, prefer `multimodal-grounded` (read the actual frame) over `verified` inferred from code-only reading. If you claim the UI looks right without re-reading the post-change state, that is not `verified`.
 
 ## Minimum Proof By Change Type
 
@@ -35,21 +37,24 @@ Do not use `done`, `fixed`, `working`, or `resolved` without naming the proof im
 | Backend, logic, or API change | Targeted test, command, script, or runtime request |
 | UI or interaction change | Browser or user-surface verification, plus static checks as needed |
 | Integration-sensitive change | Build or typecheck plus one focused behavior check |
+| Visual / design / styling claim | `multimodal-grounded`: read the attached screenshot/frame, name the file path, name the region inspected, and (when applicable) state "visually diffed against pre-change" or "not visually diffed" |
 | New app or scaffold | Setup/install succeeds, startup or health check succeeds, production build succeeds, one primary happy-path flow works, and any promised persistence or reload behavior is verified |
 
-Build, lint, and typecheck support completion claims, but they do not replace runtime or surface proof for interaction, styling, navigation, or integration promises.
+Build, lint, and typecheck support completion claims, but they do not replace runtime or surface proof for interaction, styling, navigation, or integration promises. They also do not replace `multimodal-grounded` proof for visual-fidelity claims — the visual is the surface.
 
 ## Regression And Blast Radius
 
 - Before closeout, if the repo has an automated test suite, smoke script, or documented CI entrypoint, state whether it was run on the changes.
-- If tests or smoke were not run, label regression risk as `unverified` and name what was skipped. Do not imply “no regressions” without that evidence.
+- If tests or smoke were not run, label regression risk as `unverified` and name what was skipped. Do not imply "no regressions" without that evidence.
+- For visual claims, prefer a visual diff (post-change frame vs. pre-change frame) over a prose diff. State whether the visual was diffed. If the user can attach a screenshot of the broken state, read it as part of the triage.
 
 ## Verification Order
 
 ```text
 1. Smallest relevant static check
 2. Focused executable or user-surface proof
-3. Broader validation only when warranted
+3. Multimodal-grounded proof when the claim is visual
+4. Broader validation only when warranted
 ```
 
 ## Closeout Contract
@@ -57,7 +62,7 @@ Build, lint, and typecheck support completion claims, but they do not replace ru
 Every substantive completion summary should make clear:
 
 - what changed
-- what was verified
+- what was verified (and how)
 - what remains unverified
 - what is blocked, if anything
 
@@ -67,8 +72,8 @@ Use this PR-style shape so humans can scan quickly:
 |---------|---------|
 | **Summary** | Outcome in one short paragraph |
 | **Files touched** | Paths or areas changed |
-| **Verification evidence** | Exact commands run, manual checks, user-visible surfaces exercised |
-| **Risks and unverified items** | Regressions not tested, assumptions, recommended follow-ups |
+| **Verification evidence** | Exact commands run, manual checks, user-visible surfaces exercised, screenshots/frames read (with paths) for `multimodal-grounded` claims |
+| **Risks and unverified items** | Regressions not tested, visual claims not diffed, assumptions, recommended follow-ups |
 
 ## When Verification Fails
 

--- a/.cursor/rules/minimax-m3-verification.mdc
+++ b/.cursor/rules/minimax-m3-verification.mdc
@@ -1,11 +1,11 @@
 ---
-description: "Extended verification playbook: proof selection, shell checks, browser checks, and recovery loops."
+description: "Extended M3 verification playbook: proof selection, multimodal-grounded checks, shell checks, browser checks, and recovery loops."
 alwaysApply: false
 ---
 
-# Verification Playbook
+# M3 Verification Playbook
 
-Extends the always-on `minimax-m2-status-verification` contract with check selection, shell/browser guidance, and self-review. The status labels, minimum proof table, and closeout shape live in that always-on rule — do not restate them here.
+Extends the always-on `minimax-m3-status-verification` contract with check selection, shell/browser guidance, multimodal-grounded checks, and self-review. The status labels, minimum proof table, and closeout shape live in that always-on rule — do not restate them here.
 
 ## Proof Selection
 
@@ -13,6 +13,7 @@ Extends the always-on `minimax-m2-status-verification` contract with check selec
 - Prefer the smallest proof that can honestly support the user-facing claim.
 - Strengthen the proof when the claim involves runtime behavior, interaction, styling, navigation, persistence, or integration.
 - If the deliverable promises a styling or toolchain layer (Tailwind, shadcn, routing, persistence), verify that layer directly — do not assume the scaffold wired it correctly.
+- **Visual / design / styling claim → `multimodal-grounded`**: read the attached image/frame, name the file path, name the region inspected, and check the relevant region. Do not infer from prose or from a memory of the pre-change state. See the `minimax-m3-multimodal-input` skill for the full workflow.
 
 ## Shell-Based Checks
 
@@ -34,6 +35,8 @@ Use browser verification when the user would experience the change visually or i
 - styling pipeline issues
 - end-to-end behavior the shell cannot prove
 
+For purely visual claims (a screenshot already exists, or the user attached a mock), `multimodal-grounded` is the cheaper and more direct proof than a browser pass; use the browser pass when the surface is interactive.
+
 When browser verification is unavailable, say that clearly and downgrade the claim instead of implying full proof.
 
 ## Self-Review
@@ -45,6 +48,7 @@ What would break this?
 What assumptions might be wrong?
 Is there a simpler way?
 Did I solve the actual request?
+Did I re-read the post-change visual state, or am I remembering the pre-change state?
 ```
 
 ## When Verification Fails

--- a/.cursor/rules/minimax-mcp-tools.mdc
+++ b/.cursor/rules/minimax-mcp-tools.mdc
@@ -1,5 +1,5 @@
 ---
-description: "MCP and web-tool guidance: current-doc retrieval, direct-tool preference, and version-aware external lookups."
+description: "MCP and web-tool guidance: current-doc retrieval, direct-tool preference, MCP Apps structured content, and version-aware external lookups."
 alwaysApply: false
 ---
 
@@ -14,7 +14,8 @@ When multiple paths exist, prefer:
 1. direct native tools exposed in the prompt
 2. direct plugin or MCP-backed tools exposed in the prompt
 3. MCP resource functions when available
-4. `WebSearch` and `WebFetch`
+4. MCP Apps structured content when returned by a tool
+5. `WebSearch` and `WebFetch`
 
 Do not assume old wrapper APIs are present just because they appear in older docs or rules.
 
@@ -44,6 +45,7 @@ When versions matter:
 - Follow the exact schema of currently exposed tools.
 - If the environment exposes direct tools, use them directly.
 - If the environment exposes resources instead of actions, use the resource discovery and fetch path.
+- If a tool returns MCP Apps structured content, use the structured form rather than the prose form.
 - Keep assumptions about server names and tool IDs out of general rules.
 
 ## Typical Chains
@@ -52,6 +54,7 @@ When versions matter:
 Version check -> install or configure -> verify
 Docs lookup -> implement -> behavior check
 Resource discovery -> targeted fetch -> synthesize
+Visual diff -> grounded report
 ```
 
 For version-sensitive setup guidance, prefer:
@@ -67,3 +70,4 @@ If an MCP or plugin call fails:
 - simplify the arguments
 - remove stale placeholder text
 - fall back to another available source if the integration is optional
+- if the tool returned structured content, check whether the prose view missed a useful field

--- a/.cursor/rules/model-compatibility.mdc
+++ b/.cursor/rules/model-compatibility.mdc
@@ -1,11 +1,13 @@
 ---
-description: "Model compatibility guide: prompt hierarchy, tool discipline, read-before-edit safety, and context control across models."
+description: "Model compatibility guide: prompt hierarchy, M3-first model selection, tool discipline, read-before-edit safety, and context control across models."
 alwaysApply: false
 ---
 
-# Transferable Agent Behavior
+# Transferable Agent Behavior (M3-first, model-resilient)
 
-This repo is written for MiniMax M2.7. The purpose of this file is to define the transferable execution behavior MiniMax should copy: tool-first work, read-before-edit discipline, short prompts, and context-aware problem solving that also maps well to strong GPT/Codex-style coding agents.
+This repo is tuned for MiniMax M3 first. M3 is a generational shift: 1M-token MSA context, native multimodal input (text, image, video), and higher agentic and coding benchmarks.
+
+The purpose of this file is to define the transferable execution behavior the agent should copy across models: tool-first work, read-before-edit discipline, short prompts, and context-aware problem solving that also maps well to strong GPT/Codex/Composer-style coding agents.
 
 ## Prompt Hierarchy
 
@@ -18,6 +20,17 @@ Treat the current environment as the source of truth:
 Do not assume an older rule or prompt shape is still valid just because it appears in this repo.
 Prefer a single always-on execution spine over duplicated policy spread across multiple files.
 
+## Model Selection
+
+| Need | Default | Why |
+|------|---------|-----|
+| Long context (multi-file refactor, transcript analysis, large retrieval pack, full-repo synthesis) | `MiniMax-M3` | 1M-token MSA context |
+| Visual-fidelity work, design parity, error UI triage, screenshot-driven dev | `MiniMax-M3` | Native multimodal input (text, image, video) |
+| Deep agentic / coding (SWE-Bench-class tasks, long-horizon planning) | `MiniMax-M3` | Higher agentic and coding benchmarks |
+| Anything where the user asks for "frontier" by name | `MiniMax-M3` | Positioned as the new frontier default |
+
+When the active model is **not** M3 (for example `composer-2`, GPT, or Claude), the always-on core continues to apply — tool discipline, read-before-edit, scope control, solver loop, status taxonomy. The M3-specific sections (long-context discipline, multimodal input discipline) become inert, and the agent must not promise multimodal or 1M-context behavior. Confirm the model's actual capabilities from the current runtime before relying on them.
+
 ## Main Failure Modes
 
 The most common failures are:
@@ -25,6 +38,8 @@ The most common failures are:
 - guessing file contents instead of reading them
 - teaching stale tool names as if they were universal
 - overloading the prompt with duplicate process text
+- on M3, over-loading context with raw search/fetch output instead of compressing (see `minimax-m3-long-context`)
+- on M3, making visual claims without re-reading the actual attached image/frame (see `minimax-m3-multimodal-input`)
 
 ## Tool Discipline
 
@@ -41,7 +56,7 @@ Canonical workflow lives in the always-on core **Code Discipline** section. In s
 1. Read the target file in the current session
 2. Base the change on exact contents
 3. Use the current edit primitive
-4. Verify with follow-up reads, build, tests, browser checks, or shell output
+4. Verify with follow-up reads, build, tests, browser checks, shell output, or multimodal-grounded re-reads
 ```
 
 If the environment offers a patch or search-replace edit tool, prefer it for focused edits (Composer-style agents often expose `StrReplace`; other surfaces may use `ApplyPatch` or similar).
@@ -60,3 +75,4 @@ If the environment offers a patch or search-replace edit tool, prefer it for foc
 - Prefer targeted searches over broad scans.
 - Keep durable lessons, not raw output, in active context.
 - For large work, push detailed procedures into requestable rules or skills instead of the always-on core.
+- On M3, with 1M tokens available, still compress after each iteration — see `minimax-m3-long-context`.

--- a/.cursor/rules/skill-authoring.mdc
+++ b/.cursor/rules/skill-authoring.mdc
@@ -1,5 +1,5 @@
 ---
-description: "MiniMax M2.7 skill authoring: when to use skills, how to structure them, and how to keep them deep without duplicating the core."
+description: "MiniMax M3 + Cursor 3 skill authoring: when to use skills, how to structure them, how to keep them deep without duplicating the core, and how to declare model assumptions."
 alwaysApply: false
 ---
 
@@ -40,17 +40,21 @@ metadata:
   category: workflow
   sources:
     - Official docs or standards
+  model_assumptions: []   # optional; see below
 ---
 ```
 
 Rules:
-
 - `name` must match the directory name exactly.
 - `description` must include concrete trigger language, not vague capability claims.
 - `license` should be explicit so skills stay portable outside this repo.
 - `metadata.version` should change when the skill meaningfully evolves.
 - `metadata.category` should describe the domain or workflow.
 - `metadata.sources` should name current authoritative sources when the skill depends on external behavior.
+- `metadata.model_assumptions` (optional) should name the model capabilities the skill depends on, e.g.:
+  - `multimodal-input: required` — the skill expects the user can attach images/video that the model can read natively
+  - `long-context: recommended` — the skill expects a 1M-class context window for the loader to be useful
+  - `cursor-3-runtime: required` — the skill expects the Cursor 3 / Agents Window surface
 
 ## Progressive Disclosure
 
@@ -63,6 +67,7 @@ Rules:
 - State concrete triggers in user-language, not vague capability claims.
 - Define inputs, outputs, stop conditions, and common failure modes.
 - Prefer one coherent workflow per skill over broad omnibus instructions.
+- If a skill depends on multimodal input, name that in the frontmatter and in the opening paragraph so the agent does not try to use it in a text-only environment.
 
 ## Anti-Duplication
 

--- a/.cursor/rules/tool-discovery.mdc
+++ b/.cursor/rules/tool-discovery.mdc
@@ -1,9 +1,9 @@
 ---
-description: "MiniMax M2.7 tool discovery: runtime inventory, schema-first MCP use, capability mapping, and safe fallbacks."
+description: "MiniMax M3 + Cursor 3 tool discovery: runtime inventory, schema-first MCP use, MCP Apps structured content, capability mapping, and safe fallbacks."
 alwaysApply: false
 ---
 
-# Tool Discovery
+# Tool Discovery (Cursor 3 + M3)
 
 Use this rule when the runtime surface is unfamiliar, tool-heavy, or likely to differ across environments.
 
@@ -13,7 +13,7 @@ Inventory the current surface in this order:
 
 1. direct tools exposed in the prompt
 2. browser or IDE-native tools exposed in the prompt
-3. **Cursor Marketplace** (or team marketplace) plugins already installed—same schema-first rules as other MCPs; discover tools and resources from each plugin’s descriptors before calling
+3. **Cursor Marketplace** (or team marketplace) plugins already installed — same schema-first rules as other MCPs; discover tools and resources from each plugin's descriptors before calling
 4. MCP tools and resources with their current schemas (including project-configured servers)
 5. web docs only when discovery or versions still remain unclear
 
@@ -22,6 +22,7 @@ Inventory the current surface in this order:
 - Read the current schema or descriptor before calling unfamiliar MCP tools.
 - Match the task step to the smallest tool that can honestly do it.
 - Do not infer hidden parameters or old wrapper names from memory.
+- **MCP Apps structured content (Cursor 3)**: when a tool returns structured content, prefer the structured form over reconstructing from prose. Surface it in the report faithfully.
 
 ## Capability Mapping
 
@@ -31,6 +32,8 @@ Before acting, translate the task into:
 - what must be changed
 - what must be verified
 - which currently exposed tool best serves each step
+
+For visual-fidelity work, also translate into: which image/frame must be read, and which post-change frame must be re-read after editing.
 
 ## Discovery Loop
 
@@ -55,3 +58,4 @@ Before acting, translate the task into:
 - using shell as the first choice when a direct tool is exposed
 - calling MCP tools without reading current schemas
 - hiding tool uncertainty behind confident prose
+- ignoring MCP Apps structured content and dumping it as prose

--- a/.cursor/skills/3d-web-experiences/SKILL.md
+++ b/.cursor/skills/3d-web-experiences/SKILL.md
@@ -1,16 +1,18 @@
 ---
 name: 3d-web-experiences
 description: >
-  Build distinctive, performant, production-grade 3D on the web with Three.js, React Three Fiber, and WebGL. Use when the user asks to "build a 3D scene", "add a 3D hero/landing", "make a product viewer/configurator", mentions three.js / react-three-fiber / r3f / drei / webgl / shaders, or asks to make an existing 3D scene "look good", run smoothly, or work on mobile. Covers aesthetic direction (anti-slop for 3D), lighting/material/post-processing, performance budgets, responsive WebGL, graceful degradation, and accessibility.
+  Build distinctive, performant, production-grade 3D on the web with Three.js, React Three Fiber, and WebGL. Use when the user asks to "build a 3D scene", "add a 3D hero/landing", "make a product viewer/configurator", mentions three.js / react-three-fiber / r3f / drei / webgl / shaders, or asks to make an existing 3D scene "look good", run smoothly, or work on mobile. Covers aesthetic direction (anti-slop for 3D), lighting/material/post-processing, performance budgets, responsive WebGL, graceful degradation, accessibility, and M3 multimodal parity from reference video/frames.
 license: MIT
 metadata:
-  version: "1.0.0"
+  version: "1.1.0"
   category: design
   sources:
     - Three.js official documentation (threejs.org/docs)
     - React Three Fiber docs (r3f.docs.pmnd.rs)
     - drei docs (drei.docs.pmnd.rs)
     - react-postprocessing docs (react-postprocessing.docs.pmnd.rs)
+  model_assumptions:
+    - multimodal-input: recommended
 ---
 
 # 3D Web Experiences ("3D Taste + Production Layer")
@@ -40,6 +42,15 @@ Before writing 3D code, inspect the project:
 5. If a scene already exists, respect its conventions and extend; do not rebuild from scratch.
 
 ---
+
+## Step 0.5: Multimodal Reference Parity (M3)
+
+When the user attaches a reference video, a recorded interaction, or a sequence of frames showing the look they want:
+
+- Read the actual file/frame, not a guessed description of it. On M3 the runtime can ingest video natively; treat the attachment as ground truth.
+- For "make it look like this" requests, the reference is the contract. State the path in your closeout.
+- For reference clips with motion, pick a small number of representative frames (start, mid, end) and reason about the in-between motion explicitly — do not invent the motion.
+- After the build, re-read the rendered state (post-change frame) and compare against the reference; do not claim parity from memory.
 
 ## Step 1: Commit to a 3D Direction
 

--- a/.cursor/skills/anti-slop-design/SKILL.md
+++ b/.cursor/skills/anti-slop-design/SKILL.md
@@ -1,14 +1,16 @@
 ---
 name: anti-slop-design
-description: Category-aware design skill that builds distinctive, production-grade UIs. Palettes, font pairings, UX patterns, shadcn/token integration, empty-error-loading copy, secondary slop signals, and a pre-ship second pass. Framework-agnostic.
+description: Category-aware design skill that builds distinctive, production-grade UIs. Palettes, font pairings, UX patterns, shadcn/token integration, empty-error-loading copy, secondary slop signals, multimodal design parity from mocks, and a pre-ship second pass. Framework-agnostic.
 license: MIT
 metadata:
-  version: "1.0.0"
+  version: "1.1.0"
   category: design
   sources:
     - Project design systems and token files
     - Platform accessibility guidance
     - Established product and editorial design patterns
+  model_assumptions:
+    - multimodal-input: recommended
 ---
 
 # Anti-Slop Design Skill ("Taste Layer")
@@ -79,6 +81,16 @@ These patterns are nearly as common as the list above; treat them as soft bans u
 - **Generic microcopy**: "Welcome!", "No data available", "Something went wrong" with no next step — write voice-specific, actionable copy (see reference.md).
 
 ---
+
+## Multimodal Design Parity (M3)
+
+When the user provides a design mock, screenshot, or reference image, treat the image as the contract for the build. On M3 the runtime can read the image directly; do not paraphrase from a guessed description.
+
+- `Read` the image file in the current session and reference the exact path in your closeout.
+- Cite the **region** you are matching (hero block, top-right nav, footer) when reviewing deviations — generic "looks right" is not a citation.
+- After the build, re-read the resulting state (post-change screenshot/frame) and compare against the reference; state "visually matched" only when you actually opened both.
+- If the reference is a low-fidelity wireframe, design for the wireframe's intent, not its pixel values; if the reference is a high-fidelity mock, match the values.
+- For multi-image sets (desktop, tablet, mobile mockups), re-read each before claiming a responsive match.
 
 ## Stack And Kit Integration
 

--- a/.cursor/skills/deep-research/SKILL.md
+++ b/.cursor/skills/deep-research/SKILL.md
@@ -1,14 +1,16 @@
 ---
 name: deep-research
-description: Conducts multi-step deep research on any topic using iterative search, reflection, and synthesis. Use when the user asks to research, investigate, survey, compare, analyze, deep-dive, or explore a topic in depth. Covers web research, codebase analysis, documentation review, and mixed-source investigation.
+description: Conducts multi-step deep research on any topic using iterative search, reflection, and synthesis. Use when the user asks to research, investigate, survey, compare, analyze, deep-dive, or explore a topic in depth. Covers web research, codebase analysis, documentation review, mixed-source investigation, and M3 long-context compression discipline.
 license: MIT
 metadata:
-  version: "1.1.0"
+  version: "1.2.0"
   category: research
   sources:
     - Cursor-native tool workflows
     - Documentation review and comparative research practice
     - Repo and web synthesis patterns
+  model_assumptions:
+    - long-context: recommended
 ---
 
 # Deep Research
@@ -154,6 +156,8 @@ Compression template:
 ```
 
 Drop tangential results immediately. Only carry forward "directly answers" and "provides context" findings.
+
+**M3 nudge:** with a 1M-token context, the failure mode shifts from "ran out of room" to "kept too much raw output." Apply the compression template aggressively. If you have run 3+ searches without compressing, the next reflection must include a compression pass. See `minimax-m3-long-context` for the broader retention/discard plan.
 
 ### Reflect (after every 2-3 searches)
 

--- a/.cursor/skills/incident-triage-harness/SKILL.md
+++ b/.cursor/skills/incident-triage-harness/SKILL.md
@@ -1,14 +1,16 @@
 ---
 name: incident-triage-harness
-description: Production-style incident triage workflow for logs, metrics, code, and safe mitigations. Use when debugging alerts, regressions, outages, or suspicious runtime behavior.
+description: Production-style incident triage workflow for logs, metrics, code, safe mitigations, and M3 multimodal visual evidence (screenshots, screen recordings). Use when debugging alerts, regressions, outages, or suspicious runtime behavior.
 license: MIT
 metadata:
-  version: "1.0.0"
+  version: "1.1.0"
   category: debugging
   sources:
     - Incident response and SRE triage practice
     - Evidence-first debugging workflows
     - Production mitigation and verification patterns
+  model_assumptions:
+    - multimodal-input: recommended
 ---
 
 # Incident Triage Harness
@@ -35,6 +37,15 @@ Before doing anything else, identify:
 4. **Available evidence**: logs, traces, dashboards, DB data, repo history, local repro, tests
 
 Do not jump into code edits until you have at least one concrete failure hypothesis.
+
+### Step 0a: Visual Evidence (M3)
+
+When the user attaches a screenshot of a broken UI, a screen recording of the failure, or a short clip of the symptom, the visual is primary evidence — not a supplement.
+
+- Read the actual file in the current session. Quote the visible text (error message, broken layout, empty state) directly in the report.
+- Name the file path in the closeout; do not describe the image from memory.
+- For a UI regression, treat the screenshot as the "what is broken" input. Treat a re-rendered post-fix frame as the "what is fixed" proof (`multimodal-grounded`).
+- For animation / interaction bugs, prefer a short clip over a single frame; cite the timestamp region of the relevant behavior.
 
 ---
 

--- a/.cursor/skills/minimax-m3-long-context/SKILL.md
+++ b/.cursor/skills/minimax-m3-long-context/SKILL.md
@@ -1,0 +1,127 @@
+---
+name: minimax-m3-long-context
+description: How to use MiniMax M3's 1M-token MSA context productively: what to load vs. compress, when to retrieve vs. ingest, how to keep skills shallow in the always-on prompt and deep in skills, and how to plan retention across iterations. Load when the task might exceed ~200K tokens, when the user asks to "keep all of this in mind", or when you are tempted to start a fresh session to "free context".
+license: MIT
+metadata:
+  version: "1.0.0"
+  category: workflow
+  sources:
+    - MiniMax M3 release notes (1M-token MSA context)
+    - MSA architecture overview (KV-block selection, sparse attention)
+  model_assumptions:
+    - long-context: required
+---
+
+# M3 Long-Context Discipline
+
+M3 ships a 1M-token MSA context window. The room is large; the cost of using it badly is also real. This skill teaches the retention and compression decisions that keep long-context work honest.
+
+## When to Use
+
+- The full content (files, search results, fetched pages, transcripts, design notes) might exceed ~200K tokens.
+- The user explicitly asks to "keep all of this in mind", "use the whole repo", or "don't lose anything".
+- You are tempted to start a fresh session to "free context" — that is usually a compression failure, not a context failure.
+- Multi-file refactors across a large codebase, transcript analysis, full-repo synthesis, or retrieval-augmented synthesis.
+- A research / debugging / migration task that you expect to iterate more than 3 times.
+
+For a single-file edit or a small bug fix, you do not need this skill.
+
+## Step 0: Decide Retention Per Slice
+
+For each chunk of evidence you are about to load, pick one of three retention modes **before** you load it:
+
+- **Keep verbatim** — the file is the answer, the user asked to see it, or the next step depends on exact contents.
+- **Keep summary** — the contents matter for context but you only need the high-signal lines.
+- **Drop** — the chunk is tangential, redundant with something already in context, or only useful for one specific iteration that has passed.
+
+This is the same as `deep-research` Phase 2's "drop tangential" rule, applied at the file level before loading.
+
+## Step 1: Plan The Loader
+
+Before the first read or search, write a 4–6 line plan in your scratchpad:
+
+```text
+Loader plan
+  In context at start: [system + always-on rules + user task]
+  Add verbatim:      [the few files the answer depends on]
+  Add as summary:    [reference docs, fetched pages, prior search results]
+  Drop:              [tangential files, duplicate docs, raw search output past its iteration]
+  Compress at:       [end of each iteration; before any new search round]
+```
+
+If you cannot write this plan, the task is under-specified — go back to the user or the codebase.
+
+## Step 2: Compression Rules
+
+After each iteration, replace the raw block with a 2–4 line summary. Use the `deep-research` Compression template:
+
+```
+Source: [URL or file path]
+Key finding: [1-3 sentences of relevant information]
+Confidence: [certain / likely / uncertain]
+Relevance: [directly answers sub-query / provides context / tangential]
+```
+
+Apply these caps aggressively:
+
+- Never accumulate more than 3 raw blocks of any single source.
+- After 3 iterations, the prior iteration's raw output should be down to one summary line.
+- "I might need it later" is not a retention reason. If you can recover it with a fresh `Grep` or `Read`, drop it now.
+
+## Step 3: Targeted Read vs. Full Read
+
+Default to the smallest tool that can honestly answer the question:
+
+| Need | Smallest tool |
+|------|---------------|
+| Symbol / string lookup | `Grep` |
+| "How / where / what handles this?" | `SemanticSearch` |
+| One specific function or block | `Read` with a small offset/limit |
+| Full file required for the task | `Read` (whole file) |
+| Cross-file survey of patterns | `SemanticSearch` then targeted `Read` |
+| Docs / external | `WebFetch` (one page) |
+
+Reserve full-file reads for files that are the answer, that the user asked to see, or that the next step depends on. On a 1M-token model it is tempting to read everything; that path leads to slow, expensive, and noisier reasoning.
+
+## Step 4: Skill Handoff
+
+Push deep recipes to skills instead of inlining them into the always-on prompt. This is the structural reason the repo has a tiny always-on core and many requestable rules / skills:
+
+- A long domain procedure (incident triage, design system build, 3D scene setup) belongs in a skill, not in a chat message.
+- When a skill is loaded, its content is in the active context; when the task shifts, drop the skill.
+- Do not paste full skill contents into the conversation. Reference the skill; load it on demand.
+
+## Step 5: Closeout Discipline
+
+When the task touched > 100K tokens of input, add a **Context disposition** row to the standard closeout:
+
+```text
+Context disposition:
+  Kept verbatim: [list with paths / pages]
+  Kept as summary: [list]
+  Dropped: [list with one-line reasons]
+  Compressed at iteration: [N, N+1, ...]
+  Skill(s) loaded mid-task: [list]
+```
+
+This makes the context state legible to the next reviewer (or to the next session in a hand-off).
+
+## Anti-Patterns
+
+- Full-repo re-ingest when a slice answer suffices ("let me re-read everything to be sure").
+- "Load the whole docs site" without filtering — fetch the page you need, not the whole docs.
+- Retaining raw search output past the iteration that used it. Compress or drop.
+- Starting a fresh session to "free context" instead of compressing the current one.
+- Inlining skill contents into chat instead of referencing the skill.
+- Adding a new "summary of summaries" layer that hides the original evidence — summaries should replace raw blocks, not stack on top of them.
+
+## Quick Reference
+
+```text
+PLAN    -> write a 4-6 line loader plan before the first read
+SLICE   -> pick keep-verbatim / keep-summary / drop per file before loading
+READ    -> smallest tool that answers the question (Grep > SemanticSearch > slice Read > full Read)
+COMPRESS-> after every iteration: raw -> 2-4 line summary, cap raw blocks per source
+SKILL   -> push deep recipes to skills; do not inline into the always-on prompt
+CLOSEOUT-> when input > 100K tokens, add a Context disposition row
+```

--- a/.cursor/skills/minimax-m3-multimodal-input/SKILL.md
+++ b/.cursor/skills/minimax-m3-multimodal-input/SKILL.md
@@ -1,0 +1,113 @@
+---
+name: minimax-m3-multimodal-input
+description: How to use MiniMax M3's native multimodal input (image, video) for grounded decisions in coding work. Covers reading attached images/frames, treating them as ground truth for visual claims, screenshot diffing, design parity from mockups, and routing visual evidence through reports and PRs. Load when the user attaches an image, screenshot, mockup, frame, or short clip — or when the task involves "make it look like this", "match this design", "why does this UI look wrong", or "read this error screenshot".
+license: MIT
+metadata:
+  version: "1.0.0"
+  category: workflow
+  sources:
+    - MiniMax M3 multimodal input documentation
+    - Screenshot-driven development practice
+  model_assumptions:
+    - multimodal-input: required
+---
+
+# M3 Multimodal Input
+
+M3 accepts text + image + video as native input. The point of this skill is to use that capability honestly: ground every visual claim in the actual file the model can read, and re-read the post-change state before declaring a visual fix done.
+
+## When to Use
+
+- The user attaches an image, screenshot, mockup, frame, or short clip.
+- The task involves "make it look like this", "match this design", "why does this UI look wrong", "read this error screenshot", or "match this reference video".
+- You are about to claim a visual or styling result. Any visual claim without a `multimodal-grounded` read is a guess.
+- A bug report or feature request references a UI state the user can show you (rather than describe in words).
+
+If the user is only talking about generating media (creating new images, video, TTS, music), the **`minimax-multimodal-toolkit`** skill is the right one — that skill is for output; this one is for input.
+
+## Step 0: Inventory The Input
+
+Before reasoning, identify what the user attached and what you can actually read:
+
+- **Static image** (PNG / JPG / WebP / SVG) — `Read` the file path the user provided or that the runtime surfaces.
+- **Multi-frame video or screen recording** — pick a small number of representative frames (start, mid, end) and reason about the in-between motion explicitly.
+- **Inline attachment** that the runtime renders into the chat — the model sees it directly; cite it as "the attached image" with the visible region.
+- **Multiple images in a set** (desktop + tablet + mobile mockups, before + after screenshots) — re-read each before claiming a responsive match or a fix.
+
+If you cannot actually see the file, say so and ask. Do not invent the contents of an image you did not open.
+
+## Step 1: Ground In The File, Not The Prose
+
+Always `Read` the file/frame and reference exact paths. Do not paraphrase a guessed description.
+
+- Cite the file path (`/path/to/screenshot.png`) and, when relevant, the region (`top-right nav`, `hero block`, `error toast`).
+- Quote visible text directly — error messages, button labels, empty-state copy. Do not paraphrase.
+- If the user described the image in prose, treat their prose as a hint, not as evidence. The image is the evidence.
+
+## Step 2: Visual-Fidelity Claims
+
+Any time the user (or you) say "looks right", "matches", "fixed", or "as designed", you owe a `multimodal-grounded` proof per the always-on status rule.
+
+Shape:
+
+```text
+Visual claim: [what you say it looks like]
+Reference (pre / target): [file path]
+Actual (post / current):   [file path]
+Region inspected:           [where in the frame you looked]
+Verdict:                    [matches / does not match / partial — say which and why]
+```
+
+If you cannot re-read the post-change state, downgrade the claim to `unverified` — do not say "fixed" without seeing the fix.
+
+## Step 3: Design Parity (Mock → Code)
+
+For "match this mock" work, use the image as the contract:
+
+- Identify the **regions** of the mock: hero, nav, primary CTA, footer, repeating components. Reason per region, not per pixel.
+- Match the mock's **intent**, not its exact pixel values, when the project has its own design tokens. Override tokens only when the mock is high-fidelity and the user wants a pixel match.
+- For multi-resolution mockups, hold the layout intent constant; let the responsive behavior do the work.
+- For dark/light mode parity, read both the dark and light mock frames before declaring a mode-aware fix.
+
+Cite the mock's file path in the PR / commit message so the next reviewer can re-read the contract.
+
+## Step 4: Error UI / Bug Reports
+
+When the user attaches a screenshot or clip of a broken UI:
+
+- Read it. Quote the visible error or broken text directly in the bug writeup.
+- Name the file path of the screenshot/clip in the report.
+- If the bug is interactive, ask the user to attach a short screen recording (or trigger the interaction and screenshot the result yourself in a headless browser when possible).
+- Do not invent text that is not in the image. "Likely says 'Connection failed'" without reading it is an inference, not evidence.
+
+## Step 5: Verification
+
+After a UI change:
+
+1. Render or capture the post-change state (screenshot, frame, or browser snapshot).
+2. `Read` the post-change file in the current session.
+3. Compare to the reference (pre-change state, mock, or expected behavior).
+4. State the verdict with the four fields from Step 2.
+5. If the verdict is "does not match" or "partial", say what specifically diverged and the smallest next change.
+
+This is the loop the always-on `minimax-m3-status-verification` rule calls `multimodal-grounded`. Skipping the post-change read is the most common visual-fidelity failure.
+
+## Anti-Patterns
+
+- Describing an image you did not actually open. If the runtime could not surface the file, say so.
+- "Looks right" without re-reading the post-change state.
+- Paraphrasing visible text instead of quoting it.
+- Treating a single frame as evidence for a multi-frame or animated UI.
+- Claiming a responsive match when you only re-read the desktop frame.
+- Inventing colors / spacing / typography instead of reading them from the mock.
+
+## Quick Reference
+
+```text
+INVENTORY  -> image, multi-frame video, inline attachment, multi-image set?
+GROUND     -> Read the file; cite the path; quote visible text
+CLAIM      -> any visual claim needs a reference path + actual path + region + verdict
+PARITY     -> mock is the contract; match intent by region; cite the path in the PR
+ERROR UI   -> read the screenshot/clip; quote visible text; name the path
+VERIFY     -> render/capture post-change; re-read; compare; state verdict
+```

--- a/.cursor/skills/minimax-multimodal-toolkit/SKILL.md
+++ b/.cursor/skills/minimax-multimodal-toolkit/SKILL.md
@@ -4,15 +4,18 @@ description: >
   MiniMax-native multimodal workflow for image, video, voice, music, and media-processing tasks.
   Use when the user asks to generate image/video/audio assets, wants MiniMax-specific media APIs,
   needs TTS or voice workflows, wants reproducible local media outputs, or needs FFmpeg-style
-  processing around generated media.
+  processing around generated media. M3's native multimodal input means image/video inputs can
+  be fed directly to the model for grounded decisions in coding work.
 license: MIT
 metadata:
-  version: "1.0.0"
+  version: "1.1.0"
   category: media-generation
   sources:
     - MiniMax platform media capabilities
     - Current runtime tool surface
     - FFmpeg documentation
+  model_assumptions:
+    - multimodal-input: required
 ---
 
 # MiniMax Multimodal Toolkit
@@ -52,6 +55,7 @@ Do not jump into API integration when a direct generation path is enough.
 | Existing media needs editing | Use local tooling such as FFmpeg when available | Avoid re-generation unless needed |
 | App feature using MiniMax media APIs | Implement integration code and verify with a focused request or fixture | Prefer smallest vertical slice |
 | Planning or research only | Gather current docs and synthesize | Do not implement prematurely |
+| **M3 input path: read an attached image / video frame as ground truth** | Feed the file/frame into the model directly via the runtime's multimodal input — no separate "describe the image" step | Use for design parity, error UI triage, screenshot-driven dev. See the `minimax-m3-multimodal-input` skill for the full workflow. |
 
 ---
 
@@ -69,6 +73,16 @@ Before any implementation or generation:
    - whether the user wants direct generation or product integration
 
 ---
+
+## M3 Native Multimodal Input
+
+On M3, image and video inputs can be fed to the model directly. This collapses the older "read the file, write a text description, then reason about the description" loop into a single grounded step:
+
+- The user attaches an image, screenshot, mock, or short clip; the runtime passes it to M3 as native input.
+- Ground decisions in what the image actually shows. Quote visible text, cite regions, name the file path.
+- For the full input-handling workflow (region citations, before/after diffing, multi-frame video, design parity), load the `minimax-m3-multimodal-input` skill.
+
+This skill (`minimax-multimodal-toolkit`) remains the source of truth for **generation** paths — calling MiniMax media APIs, FFmpeg pipelines, and reproducible local outputs. The two skills are complementary: this one for output, `minimax-m3-multimodal-input` for input.
 
 ## Core Rules
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing
 
-This repo is intentionally opinionated: keep the always-on core small, keep requestable rules narrow, and keep skills deep only when they cover a repeatable workflow.
+This repo is intentionally opinionated: keep the always-on core small, keep requestable rules narrow, and keep skills deep only when they cover a repeatable workflow. It is now tuned for MiniMax M3 (1M-token MSA context, native multimodal input) and Cursor 3 (Agents Window, `/worktree`, `/best-of-n`, `Await`, MCP Apps structured content).
 
 ## Core Principles
 
@@ -8,7 +8,8 @@ This repo is intentionally opinionated: keep the always-on core small, keep requ
 2. Prefer improving an existing rule or skill over adding a near-duplicate.
 3. Keep durable behavior in always-on rules.
 4. Put domain depth, references, and longer workflows in requestable rules or skills.
-5. Verify rule changes against real agent tasks, not only by reading the prose.
+5. M3-native behavior (long-context strategy, multimodal input) belongs in the always-on core as **short rules** with deeper mechanics pushed to skills.
+6. Verify rule changes against real agent tasks, not only by reading the prose.
 
 ## What Goes Where
 
@@ -20,8 +21,10 @@ Use always-on rules only for durable, high-leverage behavior such as:
 - verification language
 - tool honesty
 - scaffold discipline
+- M3 long-context discipline (one short section in the core)
+- M3 multimodal input discipline (one short section in the core)
 
-Do not add domain-specific checklists or long examples here.
+Do not add domain-specific checklists or long examples here. The core's job is the spine, not the depth.
 
 ### Requestable rules
 
@@ -44,6 +47,8 @@ Prefer:
 - concrete user-language trigger conditions
 
 Avoid omnibus skills that duplicate the core contract.
+
+For very large work, use the `minimax-m3-long-context` skill. For visual-fidelity work, use the `minimax-m3-multimodal-input` skill. Both are first-class skills in this repo, not external dependencies.
 
 ## Skill Structure
 
@@ -72,6 +77,7 @@ metadata:
   category: workflow
   sources:
     - Official docs or standards
+  model_assumptions: []    # optional; see below
 ---
 ```
 
@@ -82,6 +88,10 @@ Rules:
 - `license` should be explicit
 - `metadata.version` should be updated when the workflow materially changes
 - `metadata.sources` should point to current authoritative references when relevant
+- `metadata.model_assumptions` (optional) should name the model capabilities the skill depends on. Examples:
+  - `multimodal-input: required` — the skill expects the user can attach images/video
+  - `long-context: recommended` — the skill expects a 1M-class context window
+  - `cursor-3-runtime: required` — the skill expects the Cursor 3 / Agents Window surface
 
 ## Review Checklist
 
@@ -93,6 +103,7 @@ Before submitting a change, check:
 - Are examples short and behavior-changing, not decorative?
 - For skills: does the opening tell the agent exactly when to load it?
 - For rules: is this durable enough to justify its token cost?
+- For M3-native behavior: is the always-on core still small? If not, push depth into a skill.
 
 ## Documentation Sync
 
@@ -120,3 +131,5 @@ Do not add:
 - brittle tool names or wrappers that are not guaranteed by the runtime
 - giant lists of preferences that are already covered elsewhere
 - generated project metadata such as `.xcodeproj`, `.pbxproj`, or similar hand-written artifacts
+- "AI slop" UI patterns in any design guidance or skill
+- visual-fidelity claims without a `multimodal-grounded` path to back them

--- a/README.md
+++ b/README.md
@@ -1,28 +1,30 @@
 <div align="center">
 
-# ⚡ MiniMax M2.7 Cursor Rules
+# MiniMax M3 Cursor Rules
 
-#### A durable execution spine for repo-scale engineering, agent teams, deep skills, and dynamic tool use.
+#### A durable execution spine for repo-scale engineering, agent teams, deep skills, and dynamic tool use on M3 + Cursor 3.
 
 [![Stars](https://img.shields.io/github/stars/madebyaris/advance-minimax-m2-cursor-rules?style=flat-square&color=8b5cf6)](https://github.com/madebyaris/advance-minimax-m2-cursor-rules/stargazers)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg?style=flat-square)](LICENSE)
 [![Cursor 3](https://img.shields.io/badge/Tested-Cursor%203-blue?style=flat-square)](https://cursor.com/blog/cursor-3)
-[![MiniMax M2.7](https://img.shields.io/badge/MiniMax-M2.7-8b5cf6?style=flat-square)](https://platform.minimax.io)
+[![MiniMax M3](https://img.shields.io/badge/MiniMax-M3-8b5cf6?style=flat-square)](https://platform.minimax.io)
+[![M3 1M Context](https://img.shields.io/badge/Context-1M_MSA-22c55e?style=flat-square)](https://platform.minimax.io)
+[![M3 Multimodal](https://img.shields.io/badge/Multimodal-Native-3b82f6?style=flat-square)](https://platform.minimax.io)
 [![Any Model](https://img.shields.io/badge/Compatible-Any%20Model-22c55e?style=flat-square)](#-model-compatibility)
 
 <br/>
 
 ![Always-On Rules](https://img.shields.io/badge/Always--On-2_rules-0f172a?style=for-the-badge)
 ![Requestable Rules](https://img.shields.io/badge/Requestable-16_rules-1e293b?style=for-the-badge)
-![Skills](https://img.shields.io/badge/Skills-5_packs-14b8a6?style=for-the-badge)
+![Skills](https://img.shields.io/badge/Skills-7_packs-14b8a6?style=for-the-badge)
 
 <br/>
 
-*Built for **MiniMax M2.7**, aligned with the official release and API docs, and written to stay useful across model changes.*
+*Tuned for **MiniMax M3** (1M-token MSA context, native multimodal input) and **Cursor 3** (Agents Window, `/worktree`, `/best-of-n`, `Await`, MCP Apps). Written to stay useful across model changes.*
 
 <sub>
 
-[Quick Start](#-quick-start) · [Why This Repo](#-why-this-repo-exists) · [Architecture](#-rule-architecture) · [Runtime Modes](#-m27-runtime-modes) · [Solver Loop](#-the-solver-loop) · [AGENTS.md](#-agentsmd-for-other-ides-and-clis) · [References](#-references)
+[Quick Start](#-quick-start) · [Why This Repo](#-why-this-repo-exists) · [Architecture](#-rule-architecture) · [Runtime Modes](#-m3-runtime-modes) · [Solver Loop](#-the-solver-loop) · [AGENTS.md](#-agentsmd-for-other-ides-and-clis) · [References](#-references)
 
 </sub>
 
@@ -30,22 +32,25 @@
 
 ---
 
-## ✨ At A Glance
+## At A Glance
 
 | | What you get |
 |---|---|
-| 🧠 **Lean always-on core** | Two durable rules carry the execution spine — solver loop, scope control, code discipline, and a strict proof contract. No persona bloat. |
-| 🧩 **Progressive depth** | 16 requestable rules + 5 skill packs load only when the task needs them, so context stays clean. |
-| 🛠️ **Honest tool use** | The agent works the *current* runtime — no invented tools, no stale wrappers, no promises before the path is confirmed. |
-| ✅ **Evidence-backed closeouts** | Explicit status labels (`verified` / `unverified` / `blocked`) and minimum-proof rules per change type. |
-| 🌐 **Portable** | `docs/AGENTS.md` carries the same behavior to non-Cursor IDEs and CLIs. |
-| 🔁 **Model-resilient** | Tuned for M2.7 first, compatible with any Cursor-supported model. |
+| Lean always-on core | Two durable rules carry the execution spine — solver loop, scope control, code discipline, M3 long-context discipline, M3 multimodal input discipline, and a strict proof contract. No persona bloat. |
+| Progressive depth | 16 requestable rules + 7 skill packs load only when the task needs them, so context stays clean. |
+| M3 long-context discipline | 1M-token MSA context is a real lever, but the failure mode shifts to "kept too much raw output." A dedicated skill (`minimax-m3-long-context`) teaches the retention and compression cadence. |
+| M3 multimodal-native | Image and video inputs ground visual claims (`multimodal-grounded`). A dedicated skill (`minimax-m3-multimodal-input`) teaches the design-parity and screenshot-triage workflow. |
+| Cursor 3 surface | Explicit guidance for the Agents Window, `/worktree`, `/best-of-n`, `Await`, MCP Apps structured content, and Composer 2. |
+| Honest tool use | The agent works the *current* runtime — no invented tools, no stale wrappers, no promises before the path is confirmed. |
+| Evidence-backed closeouts | Explicit status labels (`verified` / `unverified` / `blocked` / `multimodal-grounded`) and minimum-proof rules per change type. |
+| Portable | `docs/AGENTS.md` carries the same behavior to non-Cursor IDEs and CLIs. |
+| Model-resilient | Tuned for M3 first, compatible with any Cursor-supported model. |
 
 > **The bet:** MiniMax doesn't get better from persona text. It gets better from cleaner context, smaller proving slices, better tool routing, and honest verification. Every rule here optimizes for that.
 
 ---
 
-## 🚀 Quick Start
+## Quick Start
 
 ### For Cursor
 
@@ -56,8 +61,8 @@ cp -r advance-minimax-m2-cursor-rules/.cursor your-project/.cursor
 
 That's it. Two rules are **always on**:
 
-- `.cursor/rules/minimax-m2-core.mdc` — execution behavior
-- `.cursor/rules/minimax-m2-status-verification.mdc` — status & proof contract
+- `.cursor/rules/minimax-m3-core.mdc` — execution behavior, M3 long-context discipline, M3 multimodal input discipline
+- `.cursor/rules/minimax-m3-status-verification.mdc` — status & proof contract (now including `multimodal-grounded`)
 
 Everything else is **requestable** and narrower by design — it loads when the task or file globs call for it.
 
@@ -69,20 +74,22 @@ Copy `docs/AGENTS.md` into the target repo root as `AGENTS.md`. It lives under `
 
 ---
 
-## 🗂️ Repository Layout
+## Repository Layout
 
 ```text
 .cursor/
 ├── rules/                         # 18 rules (2 always-on + 16 requestable)
-│   ├── minimax-m2-core.mdc                  ★ always-on · execution spine
-│   ├── minimax-m2-status-verification.mdc   ★ always-on · proof contract
+│   ├── minimax-m3-core.mdc                  ★ always-on · execution spine + M3 disciplines
+│   ├── minimax-m3-status-verification.mdc   ★ always-on · proof contract (+ multimodal-grounded)
 │   └── …                                    requestable: runtime + domain
-└── skills/                        # 5 deep, structured skill packs
+└── skills/                        # 7 deep, structured skill packs
     ├── anti-slop-design/
     ├── 3d-web-experiences/
     ├── deep-research/
     ├── incident-triage-harness/
-    └── minimax-multimodal-toolkit/
+    ├── minimax-multimodal-toolkit/
+    ├── minimax-m3-long-context/             # new · 1M-context retention/compression
+    └── minimax-m3-multimodal-input/         # new · native image/video input workflow
 docs/
 └── AGENTS.md                      # portable agent contract (non-Cursor)
 examples/
@@ -91,59 +98,60 @@ examples/
 
 ---
 
-## 🎯 Why This Repo Exists
+## Why This Repo Exists
 
-This repo makes MiniMax M2.7 feel strong exactly where the official release puts its emphasis:
+This repo makes MiniMax M3 feel strong exactly where the M3 release puts its emphasis:
 
-- repo-scale and end-to-end engineering
-- agent harnesses and multi-agent collaboration
-- long skill packs and detailed tool contracts
-- dynamic tool discovery in changing environments
-- proportional verification with evidence-backed closeouts
+- 1M-token MSA context — and the discipline to use it without bloating
+- native multimodal input (image, video) — and the discipline to ground visual claims in the actual file
+- higher agentic and coding benchmarks — leveraged through role separation and explicit verification
+- agent harnesses and multi-agent collaboration, including `/best-of-n` as a first-class team pattern
+- long skill packs and detailed tool contracts that load only when relevant
+- dynamic tool discovery in changing environments (Cursor 3's evolving MCP + plugin surface)
 
-The goal is **not** to make MiniMax imitate another provider's tone. It is to give M2.7 a durable execution spine that complements its official positioning around real-world engineering, complex skills, and agent workflows.
+The goal is **not** to make MiniMax imitate another provider's tone. It is to give M3 a durable execution spine that complements its official positioning around real-world engineering, complex skills, agent workflows, long context, and multimodal grounding.
 
 <details>
-<summary><b>Why M2.7-native (and what that optimizes for)</b></summary>
+<summary><b>Why M3-native (and what that optimizes for)</b></summary>
 
 <br/>
 
-MiniMax positions M2.7 as strong at real-world software engineering, full project delivery, large skill adherence, and agent teams — rather than only one-shot code generation ([release report](https://www.minimax.io/news/minimax-m27-en) · [model page](https://www.minimax.io/models/text/m27)).
+MiniMax positions M3 as a generational shift: 1M-token MSA context, native multimodal input, and higher agentic and coding benchmarks ([model page](https://platform.minimax.io)).
 
 So this repo optimizes for:
 
+- explicit retention and compression decisions on 1M tokens (not "fit it all and hope")
+- grounding every visual claim in the actual attached image/frame (`multimodal-grounded`)
 - bounded repo exploration instead of reading everything
 - smallest proving slices for large tasks
-- explicit role and handoff discipline for multi-agent work
+- explicit role and handoff discipline for multi-agent work, including `/best-of-n` for high-stakes choices
 - strong skill contracts instead of vague long prompts
 - truthful runtime and verification reporting
 
 </details>
 
 <details>
-<summary><b>The MoE note — what you can and cannot control</b></summary>
+<summary><b>The MoE / MSA note — what you can and cannot control</b></summary>
 
 <br/>
 
-These rules do **not** assume you can steer a model's internal MoE routing through persona text.
+These rules do **not** assume you can steer a model's internal routing through persona text. M3 swaps full attention for MiniMax Sparse Attention (MSA), which selects KV-blocks per query — and the controllable levers are still external:
 
-The controllable levers are:
-
-- cleaner context
+- cleaner context (with explicit retention decisions)
 - better decomposition
-- better tool routing
-- better verification loops
+- better tool routing (including the Cursor 3 surface)
+- better verification loops, including `multimodal-grounded` visual proof
 - clearer definitions of done
 
-If MiniMax performs better after a prompt rewrite, the likely reason is improved external problem structure — not magic access to hidden experts.
+If M3 performs better after a rule change, the likely reason is improved external problem structure — not magic access to hidden experts.
 
 </details>
 
 ---
 
-## 🔁 The Solver Loop
+## The Solver Loop
 
-The single most important behavior this repo transfers into M2.7:
+The single most important behavior this repo transfers into M3:
 
 ```text
 1. Define the outcome in operational terms.
@@ -151,6 +159,7 @@ The single most important behavior this repo transfers into M2.7:
 3. Find the spine: entry points, data flow, state, persistence, user-visible behavior.
 4. Build the smallest vertical slice that proves the feature works.
 5. Verify at the surface where the user experiences the change.
+   - For visual claims: re-read the actual post-change frame (multimodal-grounded).
 6. Expand scope only after the core slice works.
 ```
 
@@ -163,12 +172,13 @@ The single most important behavior this repo transfers into M2.7:
 | 3 | production build succeeds |
 | 4 | one primary happy-path flow works |
 | 5 | promised integrations (styling, routing, persistence, auth) are actually verified |
+| 6 | any visual claims are `multimodal-grounded` (re-read the post-change frame) |
 
 > **Example —** for "build a task app", prioritize `create → list → complete → persist → reload`. Delay filters, collaboration, settings, and animations until the core path works.
 
 ---
 
-## ✅ Execution Guarantees
+## Execution Guarantees
 
 A few behaviors the repo treats as non-negotiable:
 
@@ -176,13 +186,15 @@ A few behaviors the repo treats as non-negotiable:
 - Scaffolding uses the framework's official CLI / `create` / `init` path when one exists.
 - Scaffold output is inspected before continuing.
 - Runnable work is not "done" until there is **runnable proof**, not just static confidence.
+- Visual work is not "done" until the post-change frame is re-read (`multimodal-grounded`).
 - If a required check fails or is skipped, the agent reports `blocked` or `implemented but unverified` — never a false completion.
 - Browser or user-surface verification is required for UI and interaction claims.
 - Tool-based promises wait until the runtime path is confirmed.
+- 1M-token context does not free the agent from compressing; it raises the cost of failing to compress.
 
 ---
 
-## 🏗️ Rule Architecture
+## Rule Architecture
 
 The system is layered: a tiny always-on core, runtime rules that load on demand, and domain rules that attach via file globs. Depth lives in skills.
 
@@ -190,26 +202,26 @@ The system is layered: a tiny always-on core, runtime rules that load on demand,
 
 | File | Purpose |
 |------|---------|
-| `minimax-m2-core.mdc` | Durable execution behavior: solver loop, scope control, **code discipline**, truthful tool use, scaffold discipline, concise progress |
-| `minimax-m2-status-verification.mdc` | Status & proof contract: exact claim labels, proof matching, evidence-first closeouts |
+| `minimax-m3-core.mdc` | Durable execution behavior: solver loop, scope control, code discipline, M3 long-context discipline, M3 multimodal input discipline, truthful tool use, scaffold discipline, concise progress |
+| `minimax-m3-status-verification.mdc` | Status & proof contract: exact claim labels, proof matching, `multimodal-grounded` visual proof, evidence-first closeouts |
 
-### ⚙️ Runtime Rules
+### Runtime Rules
 
 | File | Purpose |
 |------|---------|
-| `model-compatibility.mdc` | Prompt hierarchy, tool discipline, context control across models |
-| `cursor-tools-mastery.mdc` | Current tool-selection patterns inside Cursor |
-| `cursor-mcp-optimization.mdc` | Browser, Figma, and Cloudflare tools with direct-action patterns |
-| `cursor-agent-orchestration.mdc` | Planning, subagents, and multi-step coordination |
-| `agent-teams.mdc` | Role boundaries, handoffs, escalation, serial vs parallel teams |
-| `tool-discovery.mdc` | Runtime tool inventory, MCP/schema discovery, safe fallbacks |
-| `minimax-mcp-tools.mdc` | Current-doc, web, and MCP/plugin lookup guidance |
-| `minimax-m2-verification.mdc` | Proportional verification playbook (shell + browser checks) |
-| `minimax-m2-self-evolution.mdc` | Iterative refinement loops and autonomous debugging |
-| `skill-authoring.mdc` | When to use skills, how to structure them, how to avoid bloat |
+| `model-compatibility.mdc` | Prompt hierarchy, M3-first model selection, tool discipline, context control across models |
+| `cursor-tools-mastery.mdc` | Cursor 3 tool-selection patterns: Agents Window, `/worktree`, `/best-of-n`, `Await`, Composer 2 |
+| `cursor-mcp-optimization.mdc` | Browser, Figma, Cloudflare tools, MCP Apps structured content, direct action patterns |
+| `cursor-agent-orchestration.mdc` | Multi-environment planning, `/best-of-n` as an orchestration primitive, `Await` for long-running branches |
+| `agent-teams.mdc` | Role boundaries, multi-environment handoffs, `/best-of-n` as a team pattern, escalation, serial vs parallel |
+| `tool-discovery.mdc` | Runtime tool inventory, MCP/schema discovery, MCP Apps structured content, safe fallbacks |
+| `minimax-mcp-tools.mdc` | Current-doc retrieval, direct-tool preference, version-aware lookups, MCP Apps structured content |
+| `minimax-m3-verification.mdc` | Proportional verification playbook (shell + browser + multimodal-grounded checks) |
+| `minimax-m3-self-evolution.mdc` | Iterative refinement loops, compress-before-iterate, autonomous debugging |
+| `skill-authoring.mdc` | When to use skills, how to structure them, how to declare `model_assumptions` |
 | `clarify-first-prompting.mdc` | Ask only on real forks, after inspecting first |
 
-### 🧱 Domain Rules
+### Domain Rules
 
 Requestable rules for cross-cutting domains — **not** per-language cookbooks. Language-specific idioms come from reading the repo, official docs, and the always-on **Code Discipline** section.
 
@@ -221,44 +233,60 @@ Requestable rules for cross-cutting domains — **not** per-language cookbooks. 
 | `devops-infrastructure.mdc` | Docker, k8s, Terraform, CI/CD — validate-before-apply, infra traps (lean) |
 | `mobile-cross-platform.mdc` | Flutter / RN / Expo — CLI-first, architecture, mobile verify (lean) |
 
-### 🧩 Skills
+### Skills
 
 Skills keep deep, domain-specific procedures out of the always-on core, then deliver large structured guidance through progressive disclosure (`SKILL.md` + optional `reference.md`).
 
 | Skill | Purpose |
 |------|---------|
-| `anti-slop-design/` | Category-aware design direction, anti-slop checks, UI polish |
-| `3d-web-experiences/` | Aesthetic direction, performance budgets, responsive WebGL, graceful degradation |
-| `deep-research/` | Iterative mixed-source research, synthesis, anti-hallucination recovery |
-| `incident-triage-harness/` | Production-style debugging and mitigation workflow |
-| `minimax-multimodal-toolkit/` | MiniMax-native image, video, voice, music, and media routing |
+| `anti-slop-design/` | Category-aware design direction, anti-slop checks, UI polish, multimodal design parity from mocks |
+| `3d-web-experiences/` | Aesthetic direction, performance budgets, responsive WebGL, graceful degradation, multimodal reference parity |
+| `deep-research/` | Iterative mixed-source research, synthesis, anti-hallucination recovery, M3 long-context compression |
+| `incident-triage-harness/` | Production-style debugging and mitigation workflow, with M3 visual evidence handling |
+| `minimax-multimodal-toolkit/` | MiniMax-native image, video, voice, music, and media routing (output side) |
+| `minimax-m3-long-context/` | 1M-token MSA context discipline: retention, compression, skill handoff, closeout context disposition |
+| `minimax-m3-multimodal-input/` | Native image/video input workflow: ground in the file, design parity, visual-fidelity claims |
 
-> **Load a skill when** the task has a repeatable workflow too detailed for the core, needs examples or category heuristics, or benefits from progressive disclosure.
-
----
-
-## ⚡ M2.7 Runtime Modes
-
-The official API exposes both `MiniMax-M2.7` and `MiniMax-M2.7-highspeed`, each with a **204,800**-token context window. The docs describe standard M2.7 at roughly **60 tps** and highspeed at roughly **100 tps**, with highspeed positioned as the same capability profile at lower latency ([text generation docs](https://platform.minimax.io/docs/guides/text-generation) · [API overview](https://platform.minimax.io/docs/api-reference/api-overview)).
-
-| Model | Best fit |
-|------|---------|
-| `MiniMax-M2.7` | Deep repo work, complex synthesis, richer multi-step tasks |
-| `MiniMax-M2.7-highspeed` | Faster interactive loops, shorter verification cycles, lower-latency coding |
+> **Load a skill when** the task has a repeatable workflow too detailed for the core, needs examples or category heuristics, or benefits from progressive disclosure. M3's 1M context still rewards "load the on-point skill, do not preload the catalog."
 
 ---
 
-## 🔬 Where M2.7 Feels Different
+## M3 Runtime Modes
 
-Three areas separate M2.7 from a generic coding model — and the optional rules deepen each without bloating the core:
+MiniMax M3 (released 2026-06-01) is the target model for this repo. It ships a 1M-token MSA context window and native multimodal input (text, image, video). The repo is tuned for M3 first; it stays correct on third-party models such as `composer-2`, GPT, or Claude — the M3-specific sections (long-context discipline, multimodal input discipline) become inert and the always-on core continues to apply.
 
-- **🤝 Agent Teams** — explicit roles, bounded handoffs, clear escalation points instead of vague multi-agent optimism.
-- **🧩 Skills** — long, high-signal contracts rather than rare workflows stuffed into the always-on prompt.
-- **🔎 Tool Discovery** — discover the live runtime surface, schemas, and MCP shape before promising capability.
+> When working in a model that is **not** M3, do not promise multimodal or 1M-context behavior. The model-selection guidance in `model-compatibility.mdc` is the source of truth for which capabilities the active model actually exposes.
 
 ---
 
-## 🧭 Model Compatibility
+## M3 + Cursor 3 Surface
+
+A quick reference for the new surface — when to use each.
+
+| Surface | When to use |
+|---------|-------------|
+| **Agents Window** | The default work surface (`Cmd+Shift+P → Agents Window`). Multi-workspace, multi-repo, parallel agents. |
+| **`/worktree`** | Isolated git worktree. Use for risky exploration, parallel branches, anything that must not collide with the main tree. |
+| **`/best-of-n`** | Run the same prompt across 2–4 models in parallel worktrees, then compare. Use for high-stakes architecture, design, or refactor decisions. |
+| **`Await`** | Wait for a background shell, subagent, or a specific output token (`Ready`, `Error`). Use for long-running dev servers, parallel subagents, slow CLIs. |
+| **MCP Apps structured content** | When an MCP tool returns structured content, prefer the structured form over prose dumping. |
+| **Composer 2** | Cursor's own model — fast, cheap iteration, ~61.7 Terminal-Bench 2.0 at $0.50/$2.50 per MTok. |
+
+> Tool names and command names can drift across Cursor builds. The decision still stands (use an isolated worktree for risky work; await long-running jobs; prefer structured MCP outputs); if a specific identifier is not exposed in your build, fall back to the next best exposed path.
+
+---
+
+## Where M3 Feels Different
+
+Three areas separate M3 from a generic coding model — and the optional rules / skills deepen each without bloating the core:
+
+- **1M-token MSA + long-context discipline** — explicit retention, compression, and skill-handoff rules, plus a dedicated `minimax-m3-long-context` skill.
+- **Native multimodal input + `multimodal-grounded` verification** — image and video inputs ground visual claims; a dedicated `minimax-m3-multimodal-input` skill teaches the workflow.
+- **Agent Teams on Cursor 3** — explicit roles, bounded handoffs (with environment + model fields), `/best-of-n` as a first-class team pattern, and `Await` for long-running branches.
+
+---
+
+## Model Compatibility
 
 The rules are designed to survive model changes:
 
@@ -267,18 +295,18 @@ The rules are designed to survive model changes:
 - tool advice is written around whatever the environment actually exposes
 - version-sensitive claims are verified at runtime, not frozen into the rules
 
-This makes the repo useful for MiniMax first, while staying compatible with other Cursor-supported models.
+The always-on core does not depend on a specific model — it teaches tool-first, read-before-edit, scope-controlled behavior that holds across M3, Composer 2, GPT, Claude, and other strong coding models. The M3-specific sections (long-context discipline, multimodal input discipline) are inert on models that do not expose those capabilities; the agent must not promise them.
 
 ---
 
-## 📐 Design Principles
+## Design Principles
 
 <table>
 <tr>
 <td width="50%" valign="top">
 
 **Keep the core small**
-Large always-on prompts waste context and often reduce execution quality. The core carries only durable, high-leverage behavior — including Code Discipline, so per-language cookbooks are unnecessary.
+Large always-on prompts waste context and often reduce execution quality. The core carries only durable, high-leverage behavior — including Code Discipline, so per-language cookbooks are unnecessary. M3-specific guidance (long-context, multimodal) lives as short sections, with depth in skills.
 
 </td>
 <td width="50%" valign="top">
@@ -298,7 +326,7 @@ Inspect manifests and CI first, match existing conventions, verify with the repo
 <td width="50%" valign="top">
 
 **Make acceptance explicit**
-Rules don't stop at "verify somehow" — they define the minimum proof per claim type, especially for new scaffolds and user-facing behavior.
+Rules don't stop at "verify somehow" — they define the minimum proof per claim type, including `multimodal-grounded` for visual claims.
 
 </td>
 </tr>
@@ -320,39 +348,41 @@ Never hand-write `.xcodeproj`, `project.pbxproj`, `.xcworkspace`, or complex `.s
 
 ---
 
-## 🧪 Example Patterns
+## Example Patterns
 
-Want concrete M2.7-native patterns instead of only rules? Start here:
+Want concrete M3-native patterns instead of only rules? Start here:
 
-- [`examples/agent-teams-product-prototype.md`](examples/agent-teams-product-prototype.md) — a bounded planner / explorer / builder / verifier workflow for multi-agent product work
-- [`.cursor/skills/incident-triage-harness/SKILL.md`](.cursor/skills/incident-triage-harness/SKILL.md) — a large-skill example for incident-style debugging and mitigation
+- [`examples/agent-teams-product-prototype.md`](examples/agent-teams-product-prototype.md) — a bounded planner / explorer / builder / verifier workflow with M3 + Cursor 3 handoff fields (environment, model) and `/best-of-n` + `Await` notes
+- [`.cursor/skills/incident-triage-harness/SKILL.md`](.cursor/skills/incident-triage-harness/SKILL.md) — a large-skill example for incident-style debugging and mitigation, now with M3 visual-evidence handling
 - [`.cursor/skills/incident-triage-harness/reference.md`](.cursor/skills/incident-triage-harness/reference.md) — companion reference showing progressive disclosure
+- [`.cursor/skills/minimax-m3-long-context/SKILL.md`](.cursor/skills/minimax-m3-long-context/SKILL.md) — the 1M-context discipline skill
+- [`.cursor/skills/minimax-m3-multimodal-input/SKILL.md`](.cursor/skills/minimax-m3-multimodal-input/SKILL.md) — the visual-input workflow skill
 
 ---
 
-## 📦 AGENTS.md For Other IDEs and CLIs
+## AGENTS.md For Other IDEs and CLIs
 
-`docs/AGENTS.md` is the portable, standalone version of M2.7 behavior for environments that use agent instruction files but don't support Cursor rules. It carries the core behavior directly instead of acting as a thin pointer.
+`docs/AGENTS.md` is the portable, standalone version of M3 behavior for environments that use agent instruction files but don't support Cursor rules. It carries the core behavior directly instead of acting as a thin pointer.
 
-It focuses on action-first execution, solver-loop thinking, scope control, read-before-edit discipline, proportional verification, explicit status labels, current-source version discipline, CLI-first scaffolding, and concise communication.
+It focuses on action-first execution, solver-loop thinking, scope control, read-before-edit discipline, proportional verification, explicit status labels (now including `multimodal-grounded`), M3 long-context discipline, M3 multimodal input discipline, current-source version discipline, CLI-first scaffolding, and concise communication.
 
 > **To use it elsewhere:** copy `docs/AGENTS.md` into the target repo root as `AGENTS.md`. If you run both `AGENTS.md` and `.cursor/rules`, keep them aligned rather than letting them drift into contradictory layers.
 
 ---
 
-## 🤝 Contributing
+## Contributing
 
-See [`CONTRIBUTING.md`](CONTRIBUTING.md) for contribution rules, the skill frontmatter contract, and placement guidance across always-on rules, requestable rules, and skills.
+See [`CONTRIBUTING.md`](CONTRIBUTING.md) for contribution rules, the skill frontmatter contract (including the optional `model_assumptions` field), and placement guidance across always-on rules, requestable rules, and skills.
 
 ---
 
-## 📚 References
+## References
 
 <details open>
-<summary><b>MiniMax</b></summary>
+<summary><b>MiniMax M3</b></summary>
 
-- [MiniMax M2.7 Release Report](https://www.minimax.io/news/minimax-m27-en)
-- [MiniMax M2.7 Model Page](https://www.minimax.io/models/text/m27)
+- [MiniMax M3 launch (VentureBeat)](https://venturebeat.com/technology/minimax-m3-debuts-eclipsing-gpt-5-5-and-gemini-3-1-pro-on-key-benchmark-performance-for-just-5-10-of-the-cost)
+- [MiniMax M3 review (Thomas Wiegold)](https://thomas-wiegold.com/blog/minimax-m3-review/)
 - [MiniMax Text Generation Docs](https://platform.minimax.io/docs/guides/text-generation)
 - [MiniMax API Overview](https://platform.minimax.io/docs/api-reference/api-overview)
 - [MiniMax Platform](https://platform.minimax.io)
@@ -360,8 +390,11 @@ See [`CONTRIBUTING.md`](CONTRIBUTING.md) for contribution rules, the skill front
 </details>
 
 <details>
-<summary><b>Cursor & others</b></summary>
+<summary><b>Cursor 3 & others</b></summary>
 
+- [Cursor 3 announcement](https://cursor.com/blog/cursor-3)
+- [Cursor 3.0 changelog](https://cursor.com/changelog/3-0)
+- [Agents Window docs](https://cursor.com/docs/agent/agents-window)
 - [Cursor Changelog](https://cursor.com/changelog)
 - [Cursor Rules Docs](https://cursor.com/docs/context/rules)
 - [Cursor Agent Best Practices](https://cursor.com/blog/agent-best-practices)
@@ -374,8 +407,8 @@ See [`CONTRIBUTING.md`](CONTRIBUTING.md) for contribution rules, the skill front
 
 <div align="center">
 
-**Made with care by [Aris Setiawan](https://github.com/madebyaris) at [MiniMax](https://minimax.io)**
+**Made with care by [Aris Setiawan](https://github.com/madebyaris) at [MiniMax](https://platform.minimax.io)**
 
-<sub>If this sharpened your agent, consider leaving a ⭐ — it helps others find it.</sub>
+<sub>If this sharpened your agent, consider leaving a star — it helps others find it.</sub>
 
 </div>

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -1,4 +1,4 @@
-# MiniMax M2.7 Agent Contract
+# MiniMax M3 Agent Contract
 
 ## Default Posture
 
@@ -8,6 +8,25 @@
 - Prefer the smallest safe change that solves the real problem.
 - Reuse existing patterns before inventing new abstractions.
 - Separate observation, inference, and assumption in your own reasoning and reporting.
+
+## M3 Capabilities (use them honestly)
+
+M3 (released 2026-06-01) is a generational shift: 1M-token MSA context, native multimodal input (text, image, video), and higher agentic and coding benchmarks. The capability is real; misuse is also real.
+
+### Long-context discipline
+
+- Decide retention vs. compression per slice before loading it. Pick: keep verbatim / keep summary / drop.
+- Compress after each iteration. Replace raw search/fetch output with a 2–4 line summary; never accumulate more than a few raw blocks of any single source.
+- Prefer targeted `Grep` / `Read` / `SemanticSearch` over full re-ingest when a slice answer suffices.
+- Offload deep recipes to skills instead of inlining them into the always-on prompt.
+- For very large work, plan a 4–6 line loader plan first: in-context at start, what to add verbatim, what to summarize, what to drop, when to compress.
+
+### Multimodal input discipline
+
+- When the user attaches an image, video frame, screenshot, mock, or clip, read the file/frame in the current session and base decisions on it. Do not paraphrase a guessed description.
+- Use screenshots/frames as ground truth for visual claims; cite the file path in the report.
+- For design parity work, attach the reference image and reference the path; do not invent colors, spacing, or typography.
+- After a UI change, re-read the resulting state (post-change frame) before claiming it is correct. Do not rely on memory of the pre-change state.
 
 ## Solver Loop
 
@@ -33,6 +52,7 @@ For non-trivial work:
 - After two failed verification attempts on the same hypothesis, stop repeating the same fix.
 - Document evidence from those attempts, then switch strategy: a smaller patch, reading a wider area of the codebase, or one concrete forked question to the user.
 - Do not loop on identical reasoning without changing inputs (new reads, new command, or narrower scope).
+- Compress raw evidence from the failing attempt before starting the next iteration.
 
 ## Mid Task Checkpointing
 
@@ -62,7 +82,7 @@ There are no per-language cookbook rules. Before writing or changing code:
 
 While changing code: smallest diff, one logical concern per change, reuse existing abstractions, handle errors the way this repo does, no drive-by refactors.
 
-After meaningful changes, run the repo's proving commands (`go test`, `cargo test`, `npm test`, `pytest`, `flutter analyze`, etc.). For architecture depth, apply SOLID and clean-structure principles. For UI or 3D, load design skills when available.
+After meaningful changes, run the repo's proving commands (`go test`, `cargo test`, `npm test`, `pytest`, `flutter analyze`, etc.). For UI changes, also re-read the post-change screenshot/frame when one is available. For architecture depth, apply SOLID and clean-structure principles. For UI or 3D, load design skills when available.
 
 ## Security And Destructive Preflight
 
@@ -75,6 +95,7 @@ After meaningful changes, run the repo's proving commands (`go test`, `cargo tes
 - If you did not verify a claim, say that directly instead of implying certainty.
 - Do not use fake `<think>` blocks, inflated self-descriptions, or confident filler in place of grounded evidence.
 - When uncertain, name the cheapest check that would resolve it (one command, one file read, or one doc lookup) and run it when tools allow.
+- For visual claims, ground in the actual attached image/frame, not in a memory or guessed description; if the user did not attach one and the claim needs it, say so.
 
 ## Status And Verification Contract
 
@@ -85,6 +106,7 @@ Use explicit status language in updates and closeouts:
 - `unverified`: the work exists but the required proof was not run
 - `blocked`: required progress or proof failed and the task cannot honestly be called done
 - `assumption`: a choice or statement depends on inference rather than direct evidence
+- `multimodal-grounded`: the claim is grounded in an attached image, video frame, screenshot, or design mock that was actually read in the current session. Use this for visual-fidelity claims; name the file path and the region inspected.
 
 Do not use `done`, `fixed`, `working`, or `resolved` without naming the proof immediately after.
 
@@ -93,15 +115,16 @@ Match the proof to the strongest claim being made:
 - localized edit: re-read or one targeted static check
 - backend, logic, or API change: targeted test, command, script, or runtime request
 - UI or interaction change: browser or user-surface verification, plus static checks as needed
+- visual / design / styling claim: `multimodal-grounded` — read the attached screenshot/frame, name the path, name the region inspected
 - integration-sensitive change: build or typecheck plus one focused behavior check
 - new app or scaffold: setup/install succeeds, startup or health check succeeds, production build succeeds, one primary happy-path flow works, and any promised persistence or reload behavior is verified
 
-**Regression and blast radius:** Before closeout, if the repo has an automated test suite, smoke script, or documented CI entrypoint, state whether it was run on your changes. If tests or smoke were not run, label regression risk as `unverified` and name what was skipped.
+**Regression and blast radius:** Before closeout, if the repo has an automated test suite, smoke script, or documented CI entrypoint, state whether it was run on your changes. If tests or smoke were not run, label regression risk as `unverified` and name what was skipped. For visual claims, prefer a visual diff (post-change frame vs. pre-change frame) over a prose diff and state whether the visual was diffed.
 
 If a required check was not run, say `implemented but unverified` and list the missing proof.
 If intended verification failed and you fall back to a weaker check, say so explicitly.
 
-**Closeout template** (substantive work): include **Summary** (outcome in one short paragraph), **Files touched** (paths or areas), **Verification evidence** (commands, manual checks, surfaces exercised), and **Risks and unverified items** (regressions not tested, assumptions, follow-ups).
+**Closeout template** (substantive work): include **Summary** (outcome in one short paragraph), **Files touched** (paths or areas), **Verification evidence** (commands, manual checks, surfaces exercised, screenshots/frames read for `multimodal-grounded` claims), and **Risks and unverified items** (regressions not tested, visual claims not diffed, assumptions, follow-ups).
 
 ## Communication
 
@@ -121,3 +144,4 @@ If intended verification failed and you fall back to a weaker check, say so expl
 - Center hero sections optically and structurally; do not bias them with asymmetric padding.
 - Do not default to overused fonts such as `Inter`, `Roboto`, `Arial`, or `Space Grotesk` unless explicitly requested.
 - Treat motion as a real design tool: purposeful entrances, scroll reveals, and hover feedback when appropriate.
+- For design parity from a reference mock or screenshot, treat the image as the contract; cite the file path and read the relevant region before claiming a match.

--- a/examples/agent-teams-product-prototype.md
+++ b/examples/agent-teams-product-prototype.md
@@ -1,12 +1,12 @@
-# M2.7 Example: Agent-Team Product Prototype
+# M3 Example: Agent-Team Product Prototype
 
-This example shows a concrete M2.7-style agent-team workflow for turning a vague product request into a verified prototype without collapsing every responsibility into one agent.
+This example shows a concrete M3 + Cursor 3 agent-team workflow for turning a vague product request into a verified prototype without collapsing every responsibility into one agent.
 
 Use it together with:
 
 - `.cursor/rules/agent-teams.mdc`
 - `.cursor/rules/cursor-agent-orchestration.mdc`
-- `.cursor/rules/minimax-m2-status-verification.mdc`
+- `.cursor/rules/minimax-m3-status-verification.mdc`
 
 ## When To Use
 
@@ -103,11 +103,16 @@ Each handoff should include:
 
 ```text
 Goal:
+Repo / workspace root:
+Environment: local | /worktree | cloud | SSH
+Model: MiniMax-M3 | composer-2 | auto | ...
 Owned surface:
 What changed or was learned:
 Open risks or assumptions:
 Next required action:
 ```
+
+The environment and model fields are M3 + Cursor 3 defaults — name them so a reviewer can reproduce the run and so that `/best-of-n` comparisons stay legible.
 
 ## Example Delegation
 
@@ -159,13 +164,22 @@ Return:
 Do not edit unless asked.
 ```
 
-## Why This Pattern Fits M2.7
+## Why This Pattern Fits M3 + Cursor 3
 
-It matches the official M2.7 emphasis on:
+It matches the M3 + Cursor 3 emphasis on:
 
 - role boundaries
 - multi-agent collaboration
 - strong repo-scale reasoning
-- evidence-backed delivery
+- evidence-backed delivery (`verified` / `unverified` / `blocked` / `multimodal-grounded`)
+- 1M-token long-context discipline when the team reads across a large repo
+- native multimodal input when the user attaches a mock, screenshot, or screen recording
+
+A few M3 + Cursor 3 mechanics that make this pattern stronger:
+
+- **`/best-of-n` for the design / architecture decision.** When the team needs to pick the strongest architecture, layout, or refactor approach, run the same prompt to 2–4 models in parallel `/worktree` sessions and synthesize. The "verifier" role then reads all outputs and picks or merges.
+- **`Await` for long-running branches.** If the verifier triggers a long-running check (browser load, e2e run, build), do not poll; use the `Await` tool on the background shell or a specific output token (`Ready`, `Compiled`, `Error`).
+- **Visual work goes through `multimodal-grounded`.** When the prototype has visual claims (a screenshot, a mock, a recorded interaction), the verifier re-reads the actual post-change frame and states `multimodal-grounded` — not `verified` from prose memory.
+- **Long-context loader plan.** On M3 the planner should also produce a 4–6 line loader plan (what is in context at start, what to add verbatim, what to summarize, what to drop, when to compress) before kicking off the explorer and builder. See the `minimax-m3-long-context` skill.
 
 The point is not to maximize the number of agents. The point is to use role separation only when it reduces context load and improves verification quality.


### PR DESCRIPTION
….md to reflect new core principles and M3-specific behaviors. Enhance README with updated descriptions, badges, and a new "At A Glance" section highlighting key features. Transition from MiniMax M2.7 to M3, emphasizing 1M-token context and multimodal input capabilities. Update agent teams and orchestration rules to include multi-environment workflows and the `/best-of-n` pattern. Remove deprecated M2.7 rules and introduce new skills for long-context and multimodal input, ensuring clarity and consistency across documentation.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Upgrade the rules and docs from MiniMax M2.7 to MiniMax M3 and Cursor 3, adding long‑context and multimodal input guidance while updating agent teaming and orchestration for multi‑environment workflows and `/best-of-n`. README and CONTRIBUTING are refreshed; two new M3 skills are included.

- **New Features**
  - Added `minimax-m3-long-context` and `minimax-m3-multimodal-input` skills for 1M-token context and native multimodal input.
  - Expanded orchestration and teams: local/`/worktree`/cloud/SSH handoffs, `/best-of-n`, and `Await`.
  - Verification now supports multimodal‑grounded claims; extended M3 verification playbook.
  - MCP/Tools: support MCP Apps structured content; improved browser/Figma/Cloudflare patterns.

- **Refactors**
  - Migrated and renamed core rules to `minimax-m3-*`; removed deprecated M2.7 guidance.
  - Consolidated Cursor 3 guidance in `cursor-tools-mastery` and `cursor-agent-orchestration`.
  - Made model compatibility M3‑first; skills can declare `model_assumptions`; updated README (badges, “At a Glance”), AGENTS, and examples.
  - Updated CONTRIBUTING with M3 + Cursor 3 principles and the rule/skill split.

<sup>Written for commit bc9a41ba6b7107f9b917ff693853702cee3ba062. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/madebyaris/advance-minimax-m2-cursor-rules/pull/26?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

